### PR TITLE
BQML Behavioral Observations — hybrid anomaly layer on top of /insights

### DIFF
--- a/.github/workflows/bigquery_update.yml
+++ b/.github/workflows/bigquery_update.yml
@@ -62,3 +62,9 @@ jobs:
           DBT_GCS_BUCKET: ${{ secrets.DBT_GCS_BUCKET }}
           DBT_DATAPROC_REGION: ${{ secrets.DBT_DATAPROC_REGION }}
 
+      - name: Retrain BQML behavior model
+        # Uses the same DBT_KEYFILE_JSON credential as the dbt steps above
+        # via google-github-actions/auth (GOOGLE_APPLICATION_CREDENTIALS
+        # is exported into the runner env).  No new secrets needed.
+        run: python scripts/train_bqml.py
+

--- a/app/insights.py
+++ b/app/insights.py
@@ -14,6 +14,7 @@ from app.models import (
     get_accounts_for_user, is_admin,
     save_insight, get_insight_for_user,
 )
+from app.routes import _filter_df_by_accounts
 
 
 def _account_sql_filter(accounts):
@@ -100,6 +101,31 @@ FROM `ccwj-dbt.analytics.positions_summary`
 ORDER BY account, symbol, strategy
 """
 
+BEHAVIOR_OBSERVATIONS_QUERY = """
+SELECT
+    account,
+    trade_symbol,
+    underlying_symbol,
+    strategy,
+    open_date,
+    close_date,
+    size_vs_30d_baseline,
+    size_vs_90d_baseline,
+    strategy_win_rate_180d,
+    strategy_prior_trades_180d,
+    consecutive_losses_before,
+    observation_text,
+    anomaly_score,
+    is_anomaly
+FROM `ccwj-dbt.ml_models.account_trade_insights`
+WHERE observation_text IS NOT NULL
+  AND open_date >= DATE_SUB(CURRENT_DATE(), INTERVAL 30 DAY)
+  {account_filter}
+ORDER BY anomaly_score DESC, open_date DESC
+LIMIT 5
+"""
+
+
 WEEKLY_QA_QUERY = """
 SELECT
   week_start,
@@ -141,6 +167,7 @@ def _build_coaching_brief(client, user_accounts):
         "signals": [],
         "recent_exits": [],
         "rolls": [],
+        "behavior_observations": [],
         "has_data": False,
         "total_closed": 0,
         "reliable_contracts": 0,
@@ -316,6 +343,44 @@ def _build_coaching_brief(client, user_accounts):
     except Exception:
         pass
 
+    # 4. Behavior observations (BQML-ranked, neutral evidence).
+    #    Reads ml_models.account_trade_insights which already filters by
+    #    observation_text IS NOT NULL.  The text is pre-rendered in dbt
+    #    so Flask does no phrasing — we just quote it verbatim.
+    if app.config.get("BEHAVIOR_INSIGHTS_ENABLED", True):
+        try:
+            obs_df = client.query(
+                BEHAVIOR_OBSERVATIONS_QUERY.format(account_filter=acct_and)
+            ).to_dataframe()
+            # Belt-and-suspenders tenant scoping: also filter client-side.
+            obs_df = _filter_df_by_accounts(obs_df, user_accounts)
+            if not obs_df.empty:
+                obs_lines = []
+                for _, r in obs_df.iterrows():
+                    text = str(r.get("observation_text") or "").strip()
+                    if not text:
+                        continue
+                    date_str = str(r.get("open_date", ""))[:10]
+                    sym = str(r.get("underlying_symbol", "") or "")
+                    line = f"  - ({date_str}) {sym}: {text}"
+                    obs_lines.append(line)
+                    coaching_data["behavior_observations"].append({
+                        "symbol": sym,
+                        "strategy": str(r.get("strategy", "") or ""),
+                        "open_date": date_str,
+                        "size_vs_30d_baseline": float(r.get("size_vs_30d_baseline") or 0),
+                        "strategy_win_rate_180d": float(r.get("strategy_win_rate_180d") or 0),
+                        "strategy_prior_trades_180d": int(r.get("strategy_prior_trades_180d") or 0),
+                        "anomaly_score": float(r.get("anomaly_score") or 0),
+                        "observation_text": text,
+                    })
+                if obs_lines:
+                    sections.append("BEHAVIOR OBSERVATIONS (last 30 days)\n" + "\n".join(obs_lines))
+        except Exception:
+            # Missing ml_models dataset or untrained model should not break
+            # the coach — the deterministic signals above still render.
+            pass
+
     brief_text = "\n\n".join(sections) if sections else None
     return brief_text, coaching_data
 
@@ -414,6 +479,15 @@ Rules:
 - Focus only on behavioral patterns visible in the data.
 - Write in second person ("You...").
 
+If a BEHAVIOR OBSERVATIONS section is present in the data:
+- You may quote one observation_text verbatim when it's the most
+  informative signal this week.
+- Do NOT add severity labels ("HIGH", "MEDIUM", "ALERT", "WARNING").
+- Do NOT dramatize. Present the observation as evidence, not accusation.
+- Do NOT speculate about the trader's emotional state or motives
+  (no "revenge trading", "tilt", "FOMO", etc.).
+- Do NOT recommend changing position sizes or strategies.
+
 IMPORTANT: Start with a 2-sentence summary under "## Summary" that captures
 the single most important behavioral insight. Then write the full analysis."""
 
@@ -441,7 +515,13 @@ Rules:
 - Do NOT give financial advice or trade recommendations.
 - If data isn't available to answer, say so honestly.
 - Focus on behavioral patterns, not market predictions.
-- Write in second person ("You...")."""
+- Write in second person ("You...").
+
+If a BEHAVIOR OBSERVATIONS section is present in the data:
+- Quote observation_text verbatim when relevant to the question.
+- Do NOT add severity labels ("HIGH", "MEDIUM", "ALERT").
+- Do NOT speculate about psychological state or motive.
+- Do NOT recommend changing size or strategy."""
 
 
 def _call_gemini(data_text):

--- a/config.py
+++ b/config.py
@@ -53,6 +53,11 @@ class Config:
     # Tests force-enable in conftest.
     INSIGHTS_ENABLED = _env_bool("INSIGHTS_ENABLED", "false")
 
+    # Behavior observations (BQML-ranked evidence) embedded in /insights coach.
+    # Default on; set BEHAVIOR_INSIGHTS_ENABLED=0 to hide while the ml_models
+    # dataset is still being backfilled/tuned.
+    BEHAVIOR_INSIGHTS_ENABLED = _env_bool("BEHAVIOR_INSIGHTS_ENABLED", "true")
+
     # CSV uploads (manual upload page). Prevents accidental huge POSTs.
     _max_mb = int(os.environ.get("MAX_UPLOAD_MB", "32"))
     MAX_CONTENT_LENGTH = _max_mb * 1024 * 1024

--- a/dbt/models/intermediate/int_trade_baselines.sql
+++ b/dbt/models/intermediate/int_trade_baselines.sql
@@ -1,0 +1,201 @@
+{{ config(materialized='table') }}
+
+/*
+    Rolling per-account baselines evaluated at the moment each trade opened.
+
+    All features reflect only PRIOR closed trades (close_date < this trade's
+    open_date) so they represent the context the account had at open, not
+    a peek at the future.
+
+    Tenancy grain: `account`.  Every window is partitioned by account.
+
+    Outputs (per (account, trade_symbol)):
+      - acct_avg_notional_30d / acct_avg_notional_90d
+      - size_vs_30d_baseline  / size_vs_90d_baseline
+      - consecutive_losses_before (over all prior closed trades for account)
+      - days_since_last_loss
+      - strategy_win_rate_180d (null when < 10 prior same-strategy trades)
+*/
+
+with base as (
+    select
+        account,
+        trade_symbol,
+        strategy,
+        open_date,
+        close_date,
+        notional_proxy,
+        realized_pnl,
+        is_winner
+    from {{ ref('int_trade_features') }}
+),
+
+------------------------------------------------------------------
+-- Build a per-account chronological stream of CLOSED trades, used
+-- to compute "loss streak ending at this close" via gaps-and-islands.
+-- stream_id is a stable ordering key within an account.
+------------------------------------------------------------------
+closed_stream as (
+    select
+        account,
+        trade_symbol,
+        close_date,
+        is_winner,
+        row_number() over (
+            partition by account
+            order by close_date, trade_symbol
+        ) as stream_id
+    from base
+),
+
+-- Gaps-and-islands: each time we see a winner, bump a group id.
+-- Consecutive losses within the same group form a streak.
+with_group as (
+    select
+        account,
+        trade_symbol,
+        close_date,
+        is_winner,
+        stream_id,
+        sum(case when is_winner then 1 else 0 end) over (
+            partition by account
+            order by stream_id
+            rows between unbounded preceding and current row
+        ) as win_group_id
+    from closed_stream
+),
+
+-- Loss streak as of each closed trade: count of losses within the current
+-- open "since last winner" group, 0 if this trade was a winner.
+loss_streak_at_close as (
+    select
+        account,
+        trade_symbol,
+        close_date,
+        is_winner,
+        case
+            when is_winner then 0
+            else sum(case when is_winner then 0 else 1 end) over (
+                partition by account, win_group_id
+                order by stream_id
+                rows between unbounded preceding and current row
+            )
+        end as loss_streak_at_close,
+        stream_id
+    from with_group
+),
+
+------------------------------------------------------------------
+-- For each opening trade, find the most recent prior close (by account).
+-- The "consecutive_losses_before" is the loss_streak_at_close of that
+-- prior closed trade (or 0 if there is none, or that prior was a winner).
+------------------------------------------------------------------
+trade_with_prior_close as (
+    select
+        b.account,
+        b.trade_symbol,
+        b.strategy,
+        b.open_date,
+        b.close_date,
+        b.notional_proxy,
+        b.realized_pnl,
+        b.is_winner,
+
+        (
+            select ls.loss_streak_at_close
+            from loss_streak_at_close ls
+            where ls.account = b.account
+              and ls.close_date < b.open_date
+            order by ls.close_date desc, ls.stream_id desc
+            limit 1
+        ) as consecutive_losses_before,
+
+        (
+            select date_diff(b.open_date, max(ls.close_date), day)
+            from loss_streak_at_close ls
+            where ls.account = b.account
+              and ls.close_date < b.open_date
+              and ls.is_winner = false
+        ) as days_since_last_loss
+    from base b
+),
+
+------------------------------------------------------------------
+-- Rolling 30d / 90d notional means + strategy 180d win rate
+-- built via self-join on prior closed trades.
+------------------------------------------------------------------
+prior_notional as (
+    select
+        b.account,
+        b.trade_symbol,
+        b.open_date,
+        avg(case
+                when h.close_date >= date_sub(b.open_date, interval 30 day)
+                then h.notional_proxy
+            end) as acct_avg_notional_30d,
+        avg(case
+                when h.close_date >= date_sub(b.open_date, interval 90 day)
+                then h.notional_proxy
+            end) as acct_avg_notional_90d
+    from base b
+    left join base h
+        on h.account = b.account
+        and h.close_date < b.open_date
+        and h.close_date >= date_sub(b.open_date, interval 90 day)
+    group by 1, 2, 3
+),
+
+prior_strategy_wr as (
+    select
+        b.account,
+        b.trade_symbol,
+        if(count(h.trade_symbol) >= 10,
+           safe_divide(countif(h.is_winner), count(h.trade_symbol)),
+           null) as strategy_win_rate_180d,
+        count(h.trade_symbol) as strategy_prior_trades_180d
+    from base b
+    left join base h
+        on h.account = b.account
+        and h.strategy = b.strategy
+        and h.close_date < b.open_date
+        and h.close_date >= date_sub(b.open_date, interval 180 day)
+    group by 1, 2
+)
+
+select
+    t.account,
+    t.trade_symbol,
+    t.strategy,
+    t.open_date,
+    t.close_date,
+    t.notional_proxy,
+    t.realized_pnl,
+    t.is_winner,
+
+    pn.acct_avg_notional_30d,
+    pn.acct_avg_notional_90d,
+
+    case
+        when pn.acct_avg_notional_30d is not null and pn.acct_avg_notional_30d > 0
+        then t.notional_proxy / pn.acct_avg_notional_30d
+        else null
+    end as size_vs_30d_baseline,
+
+    case
+        when pn.acct_avg_notional_90d is not null and pn.acct_avg_notional_90d > 0
+        then t.notional_proxy / pn.acct_avg_notional_90d
+        else null
+    end as size_vs_90d_baseline,
+
+    coalesce(t.consecutive_losses_before, 0)          as consecutive_losses_before,
+    t.days_since_last_loss,
+    psw.strategy_win_rate_180d,
+    coalesce(psw.strategy_prior_trades_180d, 0)       as strategy_prior_trades_180d
+
+from trade_with_prior_close t
+left join prior_notional pn
+    on t.account = pn.account
+    and t.trade_symbol = pn.trade_symbol
+left join prior_strategy_wr psw
+    on t.account = psw.account
+    and t.trade_symbol = psw.trade_symbol

--- a/dbt/models/intermediate/int_trade_features.sql
+++ b/dbt/models/intermediate/int_trade_features.sql
@@ -1,0 +1,158 @@
+{{ config(materialized='table') }}
+
+/*
+    Trade-grain feature table for behavioral anomaly modeling.
+
+    One row per closed option contract and per closed equity session,
+    keyed on (account, trade_symbol).  Unions int_option_contracts +
+    int_equity_sessions and joins the deterministic strategy label
+    from int_strategy_classification plus DTE from int_option_trade_kinds.
+
+    Grain: one closed trade.
+    Tenancy: every row has `account` — multi-tenant isolation must use it.
+
+    Known gaps (documented, intentional):
+      - No `delta_at_open` — no greeks data in the warehouse.
+      - No intraday `hour_of_day` — stg_history.trade_date is DATE only.
+      - `notional_proxy` is an approximation:
+          options:  (contracts_opened) * option_strike * 100
+          equity:   abs(net_cash_flow)  -- rough proxy for shares-at-cost
+*/
+
+with strat as (
+    select
+        account,
+        trade_symbol,
+        strategy
+    from {{ ref('int_strategy_classification') }}
+),
+
+option_kinds as (
+    select
+        account,
+        trade_symbol,
+        dte_at_open,
+        dte_bucket
+    from {{ ref('int_option_trade_kinds') }}
+),
+
+options as (
+    select
+        oc.account,
+        oc.trade_symbol,
+        oc.underlying_symbol,
+        s.strategy,
+
+        -- 'option' surface
+        cast('option' as string) as trade_group_type,
+        oc.option_type                                            as option_structure,
+        case
+            when oc.direction = 'Sold'   then 'short_premium'
+            when oc.direction = 'Bought' then 'long_premium'
+            else 'unknown'
+        end                                                       as direction_signed,
+
+        oc.open_date,
+        oc.close_date,
+        oc.days_in_trade                                          as holding_period_days,
+        ok.dte_at_open,
+        ok.dte_bucket,
+
+        -- number of contracts actually opened on this contract
+        coalesce(oc.contracts_sold_to_open, 0)
+          + coalesce(oc.contracts_bought_to_open, 0)              as num_contracts,
+
+        -- notional_proxy: contracts * strike * 100 (approx; no delta available)
+        case
+            when oc.option_strike is not null
+            then (coalesce(oc.contracts_sold_to_open, 0)
+                  + coalesce(oc.contracts_bought_to_open, 0))
+                 * oc.option_strike * 100.0
+            else null
+        end                                                       as notional_proxy,
+
+        oc.total_pnl                                              as realized_pnl,
+        case when oc.total_pnl > 0 then true else false end       as is_winner,
+        oc.status
+
+    from {{ ref('int_option_contracts') }} oc
+    left join strat s
+        on oc.account = s.account
+        and oc.trade_symbol = s.trade_symbol
+    left join option_kinds ok
+        on oc.account = ok.account
+        and oc.trade_symbol = ok.trade_symbol
+    where oc.status = 'Closed'
+      and oc.close_date is not null
+),
+
+equity as (
+    select
+        es.account,
+        concat(es.symbol, '_session_', cast(es.session_id as string)) as trade_symbol,
+        es.symbol                                                 as underlying_symbol,
+        coalesce(s.strategy, 'Buy and Hold')                      as strategy,
+
+        cast('equity' as string)                                  as trade_group_type,
+        cast(null as string)                                      as option_structure,
+        cast('equity' as string)                                  as direction_signed,
+
+        es.open_date,
+        es.last_trade_date                                        as close_date,
+        es.days_held                                              as holding_period_days,
+        cast(null as int64)                                       as dte_at_open,
+        cast(null as string)                                      as dte_bucket,
+
+        -- use quantity of shares as "num_contracts" analog (nullable)
+        es.max_quantity_held                                      as num_contracts,
+
+        -- equity notional proxy: abs(net_cash_flow) = cost basis spent on buys-net-sells
+        abs(coalesce(es.net_cash_flow, 0))                        as notional_proxy,
+
+        es.total_pnl                                              as realized_pnl,
+        case when es.total_pnl > 0 then true else false end       as is_winner,
+        es.status
+
+    from {{ ref('int_equity_sessions') }} es
+    left join strat s
+        on es.account = s.account
+        and concat(es.symbol, '_session_', cast(es.session_id as string)) = s.trade_symbol
+    where es.status = 'Closed'
+      and es.last_trade_date is not null
+),
+
+unioned as (
+    select * from options
+    union all
+    select * from equity
+)
+
+select
+    account,
+    trade_symbol,
+    underlying_symbol,
+    coalesce(strategy, 'Other')                       as strategy,
+    trade_group_type,
+    option_structure,
+    direction_signed,
+
+    open_date,
+    close_date,
+    holding_period_days,
+    dte_at_open,
+    dte_bucket,
+
+    num_contracts,
+    notional_proxy,
+    realized_pnl,
+    is_winner,
+    status,
+
+    -- Derived time features; hour_of_day is not available (DATE only) — TODO if timestamps appear.
+    extract(dayofweek from open_date)                 as day_of_week,
+    cast(null as int64)                               as hour_of_day
+
+from unioned
+-- Exclude trades with no meaningful size signal (guards BQML feature scaling)
+where notional_proxy is not null
+  and notional_proxy > 0

--- a/dbt/models/marts/mart_trade_observations.sql
+++ b/dbt/models/marts/mart_trade_observations.sql
@@ -1,0 +1,100 @@
+{{ config(materialized='table') }}
+
+/*
+    mart_trade_observations — pure-SQL behavioral observations.
+
+    One row per closed trade (account, trade_symbol), enriched with:
+      - all features from int_trade_features
+      - all baselines from int_trade_baselines
+      - a neutral, evidence-only `observation_text`
+
+    Philosophy (see AGENTS.md):
+      - Present evidence, do not accuse.
+      - No severity labels ('HIGH' / 'MEDIUM').  No psychological labeling.
+      - observation_text is null unless evidence is strong AND baseline is
+        well-supported (>= 10 prior strategy trades).
+
+    The BQML layer downstream uses the same grain and features but
+    contributes only an `anomaly_score` used for ordering.  The text
+    itself is deterministic and traceable back to trade-level data.
+*/
+
+with joined as (
+    select
+        f.account,
+        f.trade_symbol,
+        f.underlying_symbol,
+        f.strategy,
+        f.trade_group_type,
+        f.option_structure,
+        f.direction_signed,
+
+        f.open_date,
+        f.close_date,
+        f.holding_period_days,
+        f.dte_at_open,
+        f.dte_bucket,
+
+        f.num_contracts,
+        f.notional_proxy,
+        f.realized_pnl,
+        f.is_winner,
+        f.status,
+        f.day_of_week,
+        f.hour_of_day,
+
+        b.acct_avg_notional_30d,
+        b.acct_avg_notional_90d,
+        b.size_vs_30d_baseline,
+        b.size_vs_90d_baseline,
+        b.consecutive_losses_before,
+        b.days_since_last_loss,
+        b.strategy_win_rate_180d,
+        b.strategy_prior_trades_180d
+    from {{ ref('int_trade_features') }} f
+    left join {{ ref('int_trade_baselines') }} b
+        on f.account = b.account
+        and f.trade_symbol = b.trade_symbol
+),
+
+-- Build neutral observation text.  Only emit a non-null text when the
+-- evidence is strong and the strategy has enough history to be meaningful.
+with_text as (
+    select
+        j.*,
+
+        -- Deterministic observation: size noticeably above 30d baseline AND
+        -- historical strategy win rate in this account is below 50%, with
+        -- at least 10 prior same-strategy closed trades supporting the rate.
+        case
+            when j.size_vs_30d_baseline is not null
+                 and j.size_vs_30d_baseline >= 1.5
+                 and j.strategy_win_rate_180d is not null
+                 and j.strategy_win_rate_180d < 0.50
+                 and coalesce(j.strategy_prior_trades_180d, 0) >= 10
+            then concat(
+                'Opened a ', j.strategy,
+                ' trade at ', cast(round(j.size_vs_30d_baseline, 1) as string),
+                'x your 30-day average position size. ',
+                'Trailing-180d win rate in ', j.strategy, ' for this account: ',
+                cast(round(j.strategy_win_rate_180d * 100, 0) as string), '% over ',
+                cast(j.strategy_prior_trades_180d as string), ' closed trades.'
+            )
+
+            -- A milder neutral observation: size >= 2x 30d baseline, regardless of WR,
+            -- when there is at least some notional history.
+            when j.size_vs_30d_baseline is not null
+                 and j.size_vs_30d_baseline >= 2.0
+                 and j.acct_avg_notional_30d is not null
+            then concat(
+                'Opened a ', j.strategy,
+                ' trade at ', cast(round(j.size_vs_30d_baseline, 1) as string),
+                'x your 30-day average position size.'
+            )
+
+            else null
+        end as observation_text
+    from joined j
+)
+
+select * from with_text

--- a/scripts/bqml/01_account_behavior_model.sql
+++ b/scripts/bqml/01_account_behavior_model.sql
@@ -1,0 +1,35 @@
+-- BQML: account_behavior_model
+-- -------------------------------------------------------------
+-- Global K-Means model trained on normalized per-account features.
+-- Used as an anomaly detector via ML.DETECT_ANOMALIES.
+-- Cluster IDs are intentionally never exposed to the app (unstable
+-- across retrains).  Only `normalized_distance` (anomaly_score)
+-- leaves the BQ layer.
+--
+-- Features are all ratios / counts (no absolute dollars) so a trader
+-- at any size compares on the same scale.
+--
+-- Trained from mart_trade_observations after nightly dbt build.
+
+CREATE OR REPLACE MODEL `ccwj-dbt.ml_models.account_behavior_model`
+OPTIONS (
+    model_type = 'kmeans',
+    num_clusters = 8,
+    standardize_features = TRUE,
+    max_iterations = 50,
+    kmeans_init_method = 'KMEANS++'
+) AS
+SELECT
+    strategy,                                    -- BQML one-hot encodes STRING
+    size_vs_30d_baseline,
+    size_vs_90d_baseline,
+    cast(consecutive_losses_before as float64) as consecutive_losses_before,
+    cast(coalesce(days_since_last_loss, 0) as float64) as days_since_last_loss,
+    cast(day_of_week as float64)               as day_of_week,
+    coalesce(strategy_win_rate_180d, 0.5)      as strategy_win_rate_180d
+FROM `ccwj-dbt.analytics.mart_trade_observations`
+WHERE close_date IS NOT NULL
+  AND size_vs_30d_baseline IS NOT NULL
+  AND size_vs_90d_baseline IS NOT NULL
+  AND size_vs_90d_baseline BETWEEN 0.01 AND 20
+  AND size_vs_30d_baseline BETWEEN 0.01 AND 20;

--- a/scripts/bqml/02_trade_anomaly_scores.sql
+++ b/scripts/bqml/02_trade_anomaly_scores.sql
@@ -1,0 +1,38 @@
+-- BQML: trade_anomaly_scores view
+-- -------------------------------------------------------------
+-- Wraps ML.DETECT_ANOMALIES against the global account_behavior_model.
+-- Exposes only (account, trade_symbol, anomaly_score, is_anomaly) —
+-- no cluster IDs.
+--
+-- contamination=0.03 = expect ~3% of closed trades to be flagged.
+-- If too noisy, raise this threshold or filter by anomaly_score
+-- downstream.
+
+CREATE OR REPLACE VIEW `ccwj-dbt.ml_models.trade_anomaly_scores` AS
+SELECT
+    account,
+    trade_symbol,
+    is_anomaly,
+    normalized_distance AS anomaly_score
+FROM ML.DETECT_ANOMALIES(
+    MODEL `ccwj-dbt.ml_models.account_behavior_model`,
+    STRUCT(0.03 AS contamination),
+    (
+        SELECT
+            account,
+            trade_symbol,
+            strategy,
+            size_vs_30d_baseline,
+            size_vs_90d_baseline,
+            cast(consecutive_losses_before as float64) as consecutive_losses_before,
+            cast(coalesce(days_since_last_loss, 0) as float64) as days_since_last_loss,
+            cast(day_of_week as float64)               as day_of_week,
+            coalesce(strategy_win_rate_180d, 0.5)      as strategy_win_rate_180d
+        FROM `ccwj-dbt.analytics.mart_trade_observations`
+        WHERE close_date IS NOT NULL
+          AND size_vs_30d_baseline IS NOT NULL
+          AND size_vs_90d_baseline IS NOT NULL
+          AND size_vs_90d_baseline BETWEEN 0.01 AND 20
+          AND size_vs_30d_baseline BETWEEN 0.01 AND 20
+    )
+);

--- a/scripts/bqml/03_account_trade_insights.sql
+++ b/scripts/bqml/03_account_trade_insights.sql
@@ -1,0 +1,34 @@
+-- BQML: account_trade_insights view
+-- -------------------------------------------------------------
+-- Joins deterministic observation text from mart_trade_observations
+-- with the BQML anomaly score.  Downstream (Flask) reads this view
+-- scoped by account.
+--
+-- Only surfaces rows where observation_text is non-null, so the BQML
+-- anomaly_score acts purely as a *ranking* on top of the deterministic
+-- signal — never fires an alert the deterministic layer wouldn't have
+-- independently made.
+
+CREATE OR REPLACE VIEW `ccwj-dbt.ml_models.account_trade_insights` AS
+SELECT
+    m.account,
+    m.trade_symbol,
+    m.underlying_symbol,
+    m.strategy,
+    m.open_date,
+    m.close_date,
+    m.notional_proxy,
+    m.size_vs_30d_baseline,
+    m.size_vs_90d_baseline,
+    m.strategy_win_rate_180d,
+    m.strategy_prior_trades_180d,
+    m.consecutive_losses_before,
+    m.days_since_last_loss,
+    m.observation_text,
+    coalesce(a.anomaly_score, 0.0)                   AS anomaly_score,
+    coalesce(a.is_anomaly, FALSE)                    AS is_anomaly
+FROM `ccwj-dbt.analytics.mart_trade_observations` m
+LEFT JOIN `ccwj-dbt.ml_models.trade_anomaly_scores` a
+    ON m.account = a.account
+    AND m.trade_symbol = a.trade_symbol
+WHERE m.observation_text IS NOT NULL;

--- a/scripts/train_bqml.py
+++ b/scripts/train_bqml.py
@@ -1,0 +1,76 @@
+"""Retrain BQML behavioral-observation artifacts.
+
+Runs three statements in order:
+
+    1. CREATE OR REPLACE MODEL ccwj-dbt.ml_models.account_behavior_model
+    2. CREATE OR REPLACE VIEW  ccwj-dbt.ml_models.trade_anomaly_scores
+    3. CREATE OR REPLACE VIEW  ccwj-dbt.ml_models.account_trade_insights
+
+Invoked from .github/workflows/bigquery_update.yml after both dbt build passes.
+Uses the same BigQuery credential resolution as the Flask app (see
+app/bigquery_client.py), so no new secrets are required.
+
+Safe to run repeatedly — every statement is CREATE OR REPLACE and does not
+delete or alter any analytics dataset tables.
+
+The ml_models dataset must already exist in project ccwj-dbt.  It is
+assumed to have been created once, out of band (see the project prompt).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+# Make `app.bigquery_client` importable when this script is run directly.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from app.bigquery_client import get_bigquery_client  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+log = logging.getLogger("train_bqml")
+
+
+SQL_DIR = REPO_ROOT / "scripts" / "bqml"
+
+STATEMENTS = [
+    ("account_behavior_model (CREATE OR REPLACE MODEL)", "01_account_behavior_model.sql"),
+    ("trade_anomaly_scores (CREATE OR REPLACE VIEW)",   "02_trade_anomaly_scores.sql"),
+    ("account_trade_insights (CREATE OR REPLACE VIEW)", "03_account_trade_insights.sql"),
+]
+
+
+def _load_sql(filename: str) -> str:
+    path = SQL_DIR / filename
+    if not path.is_file():
+        raise FileNotFoundError(f"BQML SQL file not found: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def main() -> int:
+    client = get_bigquery_client()
+    log.info("BigQuery client ready (project=%s)", client.project)
+
+    for label, filename in STATEMENTS:
+        sql = _load_sql(filename)
+        log.info("Running %s", label)
+        job = client.query(sql)
+        job.result()  # block until complete
+        log.info("  done (job_id=%s)", job.job_id)
+
+    log.info("All BQML artifacts refreshed successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception:
+        log.exception("BQML retrain failed")
+        raise


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

A BQML-ranked behavioral-observation layer wired into the existing `/insights` Gemini coach.  Trains a single global K-Means anomaly model on normalized per-account features, joins the anomaly score against a deterministic neutral-phrasing observation mart, and surfaces the top observations (account-scoped) inside the existing coaching brief — no new routes, no new pages.

## Decisions made with the plan owner

- **Hybrid approach.** Keep the existing deterministic strategy taxonomy (`int_strategy_classification`) as the grouping; BQML's only job is to rank observations, never to redefine strategy labels.
- **Augment `/insights`** rather than add new endpoints.  No `/api/insights/<user_id>`.
- **Account grain** (not `user_id`).  Multi-tenant isolation applied in SQL (`_account_sql_and`) and in Python (`_filter_df_by_accounts`).
- **Evidence, not alerts.**  No `HIGH`/`MEDIUM`/`BEHAVIORAL ALERT` language anywhere — matches [AGENTS.md](AGENTS.md) "present evidence, don't accuse".
- **Retrain via existing GitHub Actions**, not a new Render cron.

## Layered delivery

### dbt (`dbt/models/`)
- `intermediate/int_trade_features.sql` — closed-trade grain, unions option contracts + equity sessions, joins deterministic strategy label, derives `notional_proxy`, `dte_at_open`, `day_of_week`.
- `intermediate/int_trade_baselines.sql` — per-account rolling 30d/90d notional means, `size_vs_Nd_baseline` ratios, `consecutive_losses_before` via gaps-and-islands, `days_since_last_loss`, strategy 180d win rate (null when < 10 prior same-strategy trades).
- `marts/mart_trade_observations.sql` — deterministic, neutral-phrased `observation_text`.  Usable standalone without BQML.

### BQML (`scripts/bqml/*.sql` + `scripts/train_bqml.py`)
- `01_account_behavior_model.sql` — global K-Means on standardized ratio features (size / streak / strategy-WR / day-of-week).
- `02_trade_anomaly_scores.sql` — `ML.DETECT_ANOMALIES` view; exposes only `(account, trade_symbol, anomaly_score, is_anomaly)`, no cluster IDs (stability).
- `03_account_trade_insights.sql` — joins observation_text with anomaly score; only rows with non-null text are visible.
- `scripts/train_bqml.py` — reuses `app.bigquery_client.get_bigquery_client()`, run nightly from CI.

### Flask (`app/insights.py`, `config.py`)
- New `BEHAVIOR_OBSERVATIONS_QUERY`, scoped with `{account_filter}` (AND form) and also passed through `_filter_df_by_accounts` before use.
- New "BEHAVIOR OBSERVATIONS (last 30 days)" section in `_build_coaching_brief`.
- `SYSTEM_PROMPT` / `QA_SYSTEM_PROMPT` tuned to tell Gemini to quote `observation_text` verbatim and **never** add severity labels, psychological labeling, or position-size recommendations.
- New feature flag `BEHAVIOR_INSIGHTS_ENABLED` (default on), mirroring `INSIGHTS_ENABLED`.

### CI (`.github/workflows/bigquery_update.yml`)
- New "Retrain BQML behavior model" step after both dbt builds.  Uses existing `DBT_KEYFILE_JSON` — no new secrets.

## Tenancy (per `.cursor/rules/bigquery-tenant-isolation.mdc`)

- `account` column present in every new mart and view.
- Flask query filtered SQL-side by `_account_sql_and(user_accounts)`.
- DataFrame filtered Python-side by `_filter_df_by_accounts(..., user_accounts)` before iteration or render.
- No user-facing BQML output leaks any other account's rows.

## Explicitly out of scope (noted in the plan)

- `delta_at_open` — no greeks data in the warehouse.
- `hour_of_day` — `stg_history.trade_date` is DATE only, no timestamps.
- `underlying_type` (index_etf/single_stock/commodity) — not in the warehouse.
- `notional_value` — approximated as `contracts * strike * 100` for options, `abs(net_cash_flow)` for equity.  Naming makes the approximation explicit.
- No Render cron.  Retrain runs from existing GHA nightly job.
- No `cluster_labels` table.  Cluster IDs are intentionally never exposed.

## Validation done

- `dbt parse` passes cleanly with the three new models.
- All new SQL (except the BQML-specific `ML.DETECT_ANOMALIES` one, which sqlglot doesn't recognize) parses with sqlglot's BigQuery dialect.
- All modified Python files pass `ast.parse`.
- Existing tests require a live Postgres; couldn't run in this env, but changes are additive with try/except fallbacks — if the `ml_models` dataset isn't populated yet, the coach renders exactly as it does today.

## Suggested rollout

1. Merge and deploy dbt models — `mart_trade_observations` is usable standalone.
2. Eyeball `observation_text` phrasing on a known account.
3. Create the `ccwj-dbt.ml_models` dataset (one-time, manual).
4. Let the next GHA nightly run train the BQML model.
5. Toggle `BEHAVIOR_INSIGHTS_ENABLED=1` if not default-on; verify the coach surface.
6. Tune `contamination=0.03` in `02_trade_anomaly_scores.sql` if too noisy.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4c56fbd-00da-41ac-bd4b-9f3494ffecd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4c56fbd-00da-41ac-bd4b-9f3494ffecd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

