### PR TITLE
Wealth: dedicated high-level dashboard + selectable home page

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -181,3 +181,4 @@ from app import schwab
 from app import first_look
 from app import strategies
 from app import profile_community
+from app import wealth

--- a/app/auth.py
+++ b/app/auth.py
@@ -10,6 +10,7 @@ from app.utils import safe_internal_next
 # Profile default "home" after login. Keys must match profile_community _ALLOWED_DEFAULT_ROUTE.
 _LANDING = {
     "weekly_review": "weekly_review",
+    "wealth": "wealth",
     "positions": "positions",
     "strategies": "strategies",
     "insights": "insights",

--- a/app/profile_community.py
+++ b/app/profile_community.py
@@ -44,7 +44,7 @@ from app.models import (
 _ALLOWED_ACCENTS = frozenset({"violet", "teal", "amber", "rose", "slate"})
 _ALLOWED_VISIBILITY = frozenset({"private", "followers", "public"})
 _ALLOWED_DEFAULT_ROUTE = frozenset({
-    "weekly_review", "positions", "strategies", "insights", "accounts", "symbols",
+    "weekly_review", "wealth", "positions", "strategies", "insights", "accounts", "symbols",
 })
 
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -118,6 +118,10 @@
                     <a class="nav-link {% if ep == 'weekly_review' %}active{% endif %}"
                        href="{{ url_for('weekly_review', account=selected_account) if selected_account else url_for('weekly_review') }}">Review</a>
                 </li>
+                <li class="nav-item">
+                    <a class="nav-link {% if ep == 'wealth' %}active{% endif %}"
+                       href="{{ url_for('wealth', account=selected_account) if selected_account else url_for('wealth') }}">Wealth</a>
+                </li>
                 <li class="nav-item dropdown">
                     <a class="nav-link dropdown-toggle {% if in_portfolio %}active{% endif %}" href="#"
                        id="navPortfolio" data-bs-toggle="dropdown" aria-expanded="false">Portfolio</a>

--- a/app/templates/wealth.html
+++ b/app/templates/wealth.html
@@ -1,0 +1,418 @@
+{% extends "base.html" %}
+
+{% block head %}
+<style>
+    .wealth-hero {
+        background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+        color: #fff;
+        border-radius: 16px;
+        padding: 2rem 2rem 1.75rem;
+        box-shadow: 0 4px 24px rgba(0,0,0,.18);
+    }
+    .wealth-hero .hero-label {
+        font-size: .72rem;
+        letter-spacing: 1.2px;
+        text-transform: uppercase;
+        opacity: .7;
+    }
+    .wealth-hero .hero-value {
+        font-size: 2.6rem;
+        font-weight: 700;
+        line-height: 1.1;
+        margin: .25rem 0 .35rem;
+    }
+    .wealth-hero .hero-asof {
+        font-size: .8rem;
+        opacity: .65;
+    }
+    .delta-grid {
+        display: grid;
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+        gap: .5rem;
+        margin-top: 1.25rem;
+    }
+    @media (max-width: 720px) {
+        .delta-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    .delta-tile {
+        background: rgba(255,255,255,.08);
+        border-radius: 10px;
+        padding: .65rem .75rem;
+    }
+    .delta-tile .delta-label {
+        font-size: .65rem;
+        letter-spacing: .6px;
+        text-transform: uppercase;
+        opacity: .65;
+    }
+    .delta-tile .delta-value { font-size: 1.05rem; font-weight: 700; margin-top: .15rem; }
+    .delta-up   { color: #4ade80; }
+    .delta-down { color: #f87171; }
+    .delta-na   { color: rgba(255,255,255,.5); }
+
+    .chart-card {
+        background: #fff;
+        border-radius: 14px;
+        box-shadow: 0 2px 12px rgba(0,0,0,.06);
+        padding: 1.4rem 1.5rem;
+    }
+    .chart-card h5 { font-weight: 700; margin-bottom: .25rem; }
+    .chart-card .chart-sub {
+        font-size: .85rem;
+        color: #6c757d;
+        margin-bottom: 1rem;
+    }
+    .chart-canvas-wrap { position: relative; height: 340px; }
+    .chart-canvas-wrap.short { height: 260px; }
+
+    .alloc-stat .alloc-num { font-size: 1.4rem; font-weight: 700; }
+    .alloc-stat .alloc-pct { font-size: .8rem; color: #6c757d; }
+
+    .toggle-group .btn {
+        font-size: .78rem;
+        padding: .25rem .65rem;
+    }
+
+    .footnote {
+        font-size: .78rem;
+        color: #6c757d;
+        margin-top: 1rem;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<h4 class="mb-3 fw-bold">Wealth</h4>
+
+{% if accounts %}
+<form method="get" class="d-flex flex-wrap align-items-end gap-2 mb-3">
+    <div>
+        <label class="form-label small fw-semibold mb-1">Account</label>
+        <select name="account" class="form-select form-select-sm" onchange="this.form.submit()">
+            <option value="">All Accounts</option>
+            {% for a in accounts %}
+            <option value="{{ a }}" {{ 'selected' if a == selected_account }}>{{ a }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <noscript><button type="submit" class="btn btn-sm btn-primary">Apply</button></noscript>
+        <a href="{{ url_for('wealth') }}" class="btn btn-sm btn-outline-secondary">Reset</a>
+    </div>
+</form>
+{% endif %}
+
+{% if error %}
+<div class="alert alert-danger small">{{ error }}</div>
+{% endif %}
+
+{% if not has_data %}
+<div class="alert alert-warning">
+    <strong>Not enough history yet.</strong>
+    Wealth needs daily account snapshots from your broker.
+    <a href="{{ url_for('upload') }}">Upload your Schwab files</a> or
+    <a href="{{ url_for('profile', tab='account') }}#schwab-sync">connect Schwab sync</a>
+    to start building your wealth timeline.
+</div>
+{% else %}
+
+{# ── HERO STRIP ── #}
+{% if hero %}
+<div class="wealth-hero mb-4">
+    <div class="hero-label">Total net worth</div>
+    <div class="hero-value">${{ "{:,.2f}".format(hero.now_value) }}</div>
+    <div class="hero-asof">
+        as of {{ hero.as_of }} · history begins {{ hero.first_snapshot_date }}
+    </div>
+
+    <div class="delta-grid">
+        {% set deltas = [
+            ('today',  'Today'),
+            ('week',   'Week'),
+            ('month',  'Month'),
+            ('ytd',    'YTD'),
+            ('all',    'All time'),
+        ] %}
+        {% for key, label in deltas %}
+        {% set d = hero.deltas[key] %}
+        <div class="delta-tile">
+            <div class="delta-label">{{ label }}</div>
+            <div class="delta-value
+                {% if d is none %}delta-na
+                {% elif d >= 0 %}delta-up
+                {% else %}delta-down{% endif %}">
+                {% if d is none %}—
+                {% else %}{{ '+' if d >= 0 else '' }}{{ "{:.1%}".format(d) }}
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+{% endif %}
+
+{# ── NET WORTH OVER TIME ── #}
+<div class="chart-card mb-4">
+    <div class="d-flex flex-wrap align-items-start justify-content-between gap-2">
+        <div>
+            <h5 class="mb-0">Net worth over time</h5>
+            <div class="chart-sub">Daily account value across all accounts. Toggle benchmarks to compare against just buying the index.</div>
+        </div>
+        <div class="toggle-group btn-group" role="group" aria-label="Benchmarks">
+            <input type="checkbox" class="btn-check" id="toggleSPY" autocomplete="off" checked>
+            <label class="btn btn-outline-secondary btn-sm" for="toggleSPY">SPY</label>
+
+            <input type="checkbox" class="btn-check" id="toggleQQQ" autocomplete="off">
+            <label class="btn btn-outline-secondary btn-sm" for="toggleQQQ">QQQ</label>
+        </div>
+    </div>
+    <div class="chart-canvas-wrap"><canvas id="networthChart"></canvas></div>
+    <p class="footnote mb-0">
+        Benchmarks are <em>rebased</em> to the same starting dollar value as your portfolio,
+        so a single y-axis is meaningful. They are not your portfolio's beta-adjusted return.
+    </p>
+</div>
+
+{# ── CONTRIBUTIONS vs GAINS ── #}
+<div class="chart-card mb-4">
+    <h5 class="mb-0">Money in vs gains</h5>
+    <div class="chart-sub">
+        How much of your account is money you put in versus growth.
+        <span class="text-muted">Estimated from your trade history — see footnote.</span>
+    </div>
+    <div class="chart-canvas-wrap"><canvas id="contribGainsChart"></canvas></div>
+    <p class="footnote mb-0">
+        Schwab CSV exports do not include deposits or withdrawals as line items,
+        so contributions are computed by identity:
+        <code>contributions = account_value − cumulative_options_pnl − cumulative_dividends − cumulative_equity_net_flow</code>.
+        Step-ups in the orange band are most likely deposits; flat means no deposits.
+    </p>
+</div>
+
+{# ── ALLOCATION ── #}
+<div class="row g-3">
+    <div class="col-md-6">
+        <div class="chart-card h-100">
+            <h5 class="mb-0">Allocation today</h5>
+            <div class="chart-sub">Equity, options market value, and cash right now.</div>
+            <div class="chart-canvas-wrap short"><canvas id="allocNowChart"></canvas></div>
+            <div class="row text-center mt-3">
+                <div class="col-4 alloc-stat">
+                    <div class="alloc-num">${{ "{:,.0f}".format(alloc_now.equity) }}</div>
+                    <div class="alloc-pct">Equity</div>
+                </div>
+                <div class="col-4 alloc-stat">
+                    <div class="alloc-num">${{ "{:,.0f}".format(alloc_now.option) }}</div>
+                    <div class="alloc-pct">Options</div>
+                </div>
+                <div class="col-4 alloc-stat">
+                    <div class="alloc-num">${{ "{:,.0f}".format(alloc_now.cash) }}</div>
+                    <div class="alloc-pct">Cash</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="chart-card h-100">
+            <h5 class="mb-0">Allocation a year ago</h5>
+            <div class="chart-sub">
+                {% if alloc_year_ago %}
+                As of {{ alloc_year_ago.as_of }}.
+                {% else %}
+                Not enough history yet — needs at least 12 months of snapshots.
+                {% endif %}
+            </div>
+            <div class="chart-canvas-wrap short"><canvas id="allocYearAgoChart"></canvas></div>
+            {% if alloc_year_ago %}
+            <div class="row text-center mt-3">
+                <div class="col-4 alloc-stat">
+                    <div class="alloc-num">${{ "{:,.0f}".format(alloc_year_ago.equity) }}</div>
+                    <div class="alloc-pct">Equity</div>
+                </div>
+                <div class="col-4 alloc-stat">
+                    <div class="alloc-num">${{ "{:,.0f}".format(alloc_year_ago.option) }}</div>
+                    <div class="alloc-pct">Options</div>
+                </div>
+                <div class="col-4 alloc-stat">
+                    <div class="alloc-num">${{ "{:,.0f}".format(alloc_year_ago.cash) }}</div>
+                    <div class="alloc-pct">Cash</div>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+{% endif %}
+{% endblock %}
+
+{% block scripts %}
+{% if has_data %}
+<script>
+(function() {
+    var nw       = {{ networth_json | safe }};
+    var spy      = {{ spy_json | safe }};
+    var qqq      = {{ qqq_json | safe }};
+    var cg       = {{ contrib_gains_json | safe }};
+    var allocNow = {{ alloc_now_json | safe }};
+    var allocYA  = {{ alloc_year_ago_json | safe }};
+
+    function fmtUSD(v) {
+        if (v === null || v === undefined || isNaN(v)) return '—';
+        var abs = Math.abs(v);
+        if (abs >= 1000) return '$' + (v/1000).toFixed(1) + 'k';
+        return '$' + v.toFixed(0);
+    }
+    function fmtUSDFull(v) {
+        if (v === null || v === undefined || isNaN(v)) return '—';
+        return '$' + Number(v).toLocaleString(undefined, {minimumFractionDigits: 2, maximumFractionDigits: 2});
+    }
+
+    /* ── Net worth over time ── */
+    if (nw && nw.dates && nw.dates.length) {
+        var ctx = document.getElementById('networthChart');
+        var datasets = [{
+            label: 'Net worth',
+            data: nw.values,
+            borderColor: '#6f42c1',
+            backgroundColor: 'rgba(111,66,193,0.08)',
+            fill: true,
+            tension: .15,
+            pointRadius: 0,
+            borderWidth: 2.2,
+        }];
+        if (spy && spy.dates && spy.dates.length === nw.dates.length) {
+            datasets.push({
+                label: 'SPY (rebased)',
+                data: spy.values,
+                borderColor: '#0d6efd',
+                borderDash: [5, 4],
+                fill: false,
+                tension: .15,
+                pointRadius: 0,
+                borderWidth: 1.7,
+                hidden: !document.getElementById('toggleSPY').checked,
+            });
+        }
+        if (qqq && qqq.dates && qqq.dates.length === nw.dates.length) {
+            datasets.push({
+                label: 'QQQ (rebased)',
+                data: qqq.values,
+                borderColor: '#fd7e14',
+                borderDash: [5, 4],
+                fill: false,
+                tension: .15,
+                pointRadius: 0,
+                borderWidth: 1.7,
+                hidden: !document.getElementById('toggleQQQ').checked,
+            });
+        }
+        var nwChart = new Chart(ctx, {
+            type: 'line',
+            data: { labels: nw.dates, datasets: datasets },
+            options: {
+                responsive: true, maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    legend: { position: 'top', labels: { usePointStyle: true, pointStyle: 'line', boxWidth: 26, padding: 12 } },
+                    tooltip: { callbacks: { label: function(ctx) { return ctx.dataset.label + ': ' + fmtUSDFull(ctx.parsed.y); } } }
+                },
+                scales: {
+                    x: { ticks: { maxTicksLimit: 12, maxRotation: 45 }, grid: { display: false } },
+                    y: { ticks: { callback: fmtUSD } }
+                }
+            }
+        });
+        function syncToggle(id, datasetIndex) {
+            var el = document.getElementById(id);
+            if (!el) return;
+            el.addEventListener('change', function() {
+                var ds = nwChart.data.datasets[datasetIndex];
+                if (ds) {
+                    ds.hidden = !el.checked;
+                    nwChart.update();
+                }
+            });
+        }
+        syncToggle('toggleSPY', 1);
+        syncToggle('toggleQQQ', 2);
+    }
+
+    /* ── Contributions vs gains ── */
+    if (cg && cg.dates && cg.dates.length) {
+        new Chart(document.getElementById('contribGainsChart'), {
+            type: 'line',
+            data: {
+                labels: cg.dates,
+                datasets: [
+                    {
+                        label: 'Money in (estimated)',
+                        data: cg.contributions,
+                        backgroundColor: 'rgba(253,126,20,0.35)',
+                        borderColor: '#fd7e14',
+                        fill: 'origin',
+                        tension: .1,
+                        pointRadius: 0,
+                        borderWidth: 1.5,
+                        order: 2,
+                    },
+                    {
+                        label: 'Gains (estimated)',
+                        data: cg.gains,
+                        backgroundColor: 'rgba(45,134,89,0.30)',
+                        borderColor: '#2d8659',
+                        fill: '-1',
+                        tension: .1,
+                        pointRadius: 0,
+                        borderWidth: 1.5,
+                        order: 1,
+                    },
+                ]
+            },
+            options: {
+                responsive: true, maintainAspectRatio: false,
+                interaction: { mode: 'index', intersect: false },
+                plugins: {
+                    legend: { position: 'top', labels: { usePointStyle: true, pointStyle: 'rect', boxWidth: 14, padding: 12 } },
+                    tooltip: { callbacks: { label: function(ctx) { return ctx.dataset.label + ': ' + fmtUSDFull(ctx.parsed.y); } } }
+                },
+                scales: {
+                    x: { ticks: { maxTicksLimit: 12, maxRotation: 45 }, grid: { display: false } },
+                    y: { stacked: true, ticks: { callback: fmtUSD } }
+                }
+            }
+        });
+    }
+
+    /* ── Allocation donuts ── */
+    function donut(canvasId, data) {
+        if (!data) return;
+        var values = [data.equity || 0, data.option || 0, data.cash || 0];
+        if (values.reduce(function(a,b){ return a + Math.abs(b); }, 0) === 0) return;
+        new Chart(document.getElementById(canvasId), {
+            type: 'doughnut',
+            data: {
+                labels: ['Equity', 'Options', 'Cash'],
+                datasets: [{
+                    data: values,
+                    backgroundColor: ['#6f42c1', '#fd7e14', '#0d6efd'],
+                    borderColor: '#fff',
+                    borderWidth: 2,
+                }]
+            },
+            options: {
+                responsive: true, maintainAspectRatio: false,
+                plugins: {
+                    legend: { position: 'bottom', labels: { padding: 12, boxWidth: 12 } },
+                    tooltip: { callbacks: { label: function(ctx) { return ctx.label + ': ' + fmtUSDFull(ctx.parsed); } } }
+                },
+                cutout: '62%',
+            }
+        });
+    }
+    donut('allocNowChart', allocNow);
+    donut('allocYearAgoChart', allocYA);
+})();
+</script>
+{% endif %}
+{% endblock %}

--- a/app/wealth.py
+++ b/app/wealth.py
@@ -1,0 +1,380 @@
+"""
+Wealth — high-level "how is my net worth doing" page.
+
+Process-first product, but this is the *context* layer: a wealth dashboard
+that answers the boring-but-loved questions:
+
+  - What am I worth right now?
+  - How has that changed over time?
+  - How does it compare to just buying SPY?
+  - Of the dollars I have, how much did I deposit vs. how much did the
+    account grow?
+  - What's my allocation today vs. a year ago?
+
+Reads from `mart_wealth_daily` and `stg_daily_prices`.  No heavy
+aggregation in Python — Flask just shapes data for Chart.js.
+
+Tenancy: every BigQuery read is scoped by user accounts in SQL AND
+filtered again client-side via _filter_df_by_accounts before render.
+See .cursor/rules/bigquery-tenant-isolation.mdc.
+"""
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+
+import pandas as pd
+from flask import render_template, request
+from flask_login import login_required, current_user
+
+from app import app
+from app.bigquery_client import get_bigquery_client
+from app.models import get_accounts_for_user, is_admin
+from app.routes import _filter_df_by_accounts
+
+
+# ------------------------------------------------------------------
+# SQL (account-scoped via {account_filter})
+# ------------------------------------------------------------------
+
+WEALTH_DAILY_QUERY = """
+SELECT
+    account,
+    date,
+    account_value,
+    equity_value,
+    option_value,
+    cash_value,
+    cumulative_options_pnl,
+    cumulative_dividends,
+    cumulative_equity_net_flow,
+    cumulative_trading_cashflow,
+    implied_contributions,
+    implied_gains
+FROM `ccwj-dbt.analytics.mart_wealth_daily`
+WHERE date IS NOT NULL
+  {account_filter}
+ORDER BY account, date
+"""
+
+# SPY/QQQ daily closes for benchmark overlay.  No account scoping needed:
+# stg_daily_prices is keyed on (account, symbol, date) where account is
+# an artifact of the price-fetch pipeline, not a tenant column.  We
+# de-dupe to one close per (symbol, date) in SQL.
+BENCHMARK_QUERY = """
+SELECT symbol, date, ANY_VALUE(close_price) AS close_price
+FROM `ccwj-dbt.analytics.stg_daily_prices`
+WHERE symbol IN ('SPY', 'QQQ')
+  AND close_price IS NOT NULL AND close_price > 0
+  AND date >= @start_date
+GROUP BY symbol, date
+ORDER BY symbol, date
+"""
+
+
+def _account_sql_and(accounts):
+    """AND account IN (...) clause for queries that already have a WHERE.
+
+    accounts=None means admin; emit no filter.
+    accounts=[] means a logged-in user with zero accounts; force empty.
+    """
+    if accounts is None:
+        return ""
+    if not accounts:
+        return "AND 1 = 0"
+    quoted = ", ".join(f"'{a.replace(chr(39), chr(39)+chr(39))}'" for a in accounts)
+    return f"AND account IN ({quoted})"
+
+
+def _user_accounts_for_request(selected_account: str):
+    """Resolve user accounts for this request, honoring the optional
+    single-account focus from the ?account= query string."""
+    if is_admin(current_user.username):
+        base = None
+    else:
+        base = get_accounts_for_user(current_user.id)
+    if selected_account:
+        if base is None:
+            return [selected_account]
+        return [a for a in base if a == selected_account] or base
+    return base
+
+
+# ------------------------------------------------------------------
+# Pure helpers — no BQ, easy to reason about
+# ------------------------------------------------------------------
+
+def _delta_pct(now: float, then: float):
+    """Percent change as a fraction (0.18 = +18%).  None if base is 0/None."""
+    if then is None or now is None:
+        return None
+    if then == 0:
+        return None
+    return (now - then) / then
+
+
+def _value_on_or_before(daily_total: pd.DataFrame, target: date):
+    """Pick the most recent (date, total_value) row with date <= target.
+    Returns None if no such row.  daily_total has columns
+    ('date', 'account_value')."""
+    if daily_total.empty:
+        return None
+    mask = daily_total["date"] <= pd.Timestamp(target).date() \
+           if hasattr(daily_total["date"].iloc[0], "year") \
+           else daily_total["date"] <= target
+    sub = daily_total[mask]
+    if sub.empty:
+        return None
+    return float(sub.iloc[-1]["account_value"])
+
+
+def _build_hero(daily_total: pd.DataFrame):
+    """Compute hero number + period deltas from the all-accounts daily series."""
+    if daily_total.empty:
+        return None
+
+    today = daily_total.iloc[-1]
+    now_value = float(today["account_value"])
+    now_date = today["date"]
+    if hasattr(now_date, "to_pydatetime"):
+        now_date = now_date.to_pydatetime().date()
+    elif hasattr(now_date, "date"):
+        now_date = now_date.date()
+
+    # Anchors: the closest snapshot on-or-before each target date.
+    def _value_at_offset(days: int):
+        target = now_date - timedelta(days=days)
+        return _value_on_or_before(daily_total, target)
+
+    # YTD anchor = last snapshot of previous year
+    ytd_target = date(now_date.year, 1, 1) - timedelta(days=1)
+    all_time = float(daily_total.iloc[0]["account_value"])
+    first_date = daily_total.iloc[0]["date"]
+    if hasattr(first_date, "to_pydatetime"):
+        first_date = first_date.to_pydatetime().date()
+    elif hasattr(first_date, "date"):
+        first_date = first_date.date()
+
+    return {
+        "now_value": now_value,
+        "as_of": str(now_date),
+        "first_snapshot_date": str(first_date),
+        "deltas": {
+            "today":   _delta_pct(now_value, _value_at_offset(1)),
+            "week":    _delta_pct(now_value, _value_at_offset(7)),
+            "month":   _delta_pct(now_value, _value_at_offset(30)),
+            "ytd":     _delta_pct(now_value, _value_on_or_before(daily_total, ytd_target)),
+            "all":     _delta_pct(now_value, all_time),
+        },
+    }
+
+
+def _build_networth_series(daily_total: pd.DataFrame):
+    """Daily net-worth line: dates + account_value summed across accounts."""
+    if daily_total.empty:
+        return {"dates": [], "values": []}
+    return {
+        "dates": [str(d) for d in daily_total["date"].tolist()],
+        "values": [round(float(v), 2) for v in daily_total["account_value"].tolist()],
+    }
+
+
+def _build_benchmark_series(daily_total: pd.DataFrame, bench_df: pd.DataFrame, symbol: str):
+    """Rebase a benchmark to the trader's first net-worth dollar value
+    so they share the same y-axis at t=0.  Returns aligned series at the
+    SAME dates as daily_total (forward-filling the benchmark)."""
+    if daily_total.empty or bench_df.empty:
+        return {"dates": [], "values": []}
+
+    sym = bench_df[bench_df["symbol"] == symbol].copy()
+    if sym.empty:
+        return {"dates": [], "values": []}
+    sym = sym.sort_values("date").drop_duplicates("date", keep="last")
+
+    # Anchor at the first net-worth date with a benchmark close on-or-before.
+    nw = daily_total.sort_values("date").reset_index(drop=True)
+    start_value = float(nw.iloc[0]["account_value"])
+    start_date = nw.iloc[0]["date"]
+
+    bench_anchor = sym[sym["date"] <= start_date]
+    if bench_anchor.empty:
+        bench_anchor = sym[sym["date"] >= start_date]
+        if bench_anchor.empty:
+            return {"dates": [], "values": []}
+        anchor_close = float(bench_anchor.iloc[0]["close_price"])
+    else:
+        anchor_close = float(bench_anchor.iloc[-1]["close_price"])
+
+    if anchor_close == 0:
+        return {"dates": [], "values": []}
+
+    # Forward-fill: for each net-worth date, use the most recent benchmark close
+    # on-or-before that date.  Implemented with merge_asof.
+    nw["_d"] = pd.to_datetime(nw["date"])
+    sym["_d"] = pd.to_datetime(sym["date"])
+    merged = pd.merge_asof(
+        nw.sort_values("_d"),
+        sym.sort_values("_d")[["_d", "close_price"]].rename(columns={"close_price": "bench_close"}),
+        on="_d",
+        direction="backward",
+    )
+
+    rebased = merged["bench_close"].fillna(anchor_close) / anchor_close * start_value
+    return {
+        "dates": [str(d) for d in nw["date"].tolist()],
+        "values": [round(float(v), 2) for v in rebased.tolist()],
+    }
+
+
+def _build_contrib_vs_gains(daily_total: pd.DataFrame):
+    """Stacked-area data: implied contributions vs implied gains over time."""
+    if daily_total.empty:
+        return {"dates": [], "contributions": [], "gains": []}
+
+    return {
+        "dates": [str(d) for d in daily_total["date"].tolist()],
+        # Clip to >= 0 for display: gains can be negative on a bad year
+        # (account_value < contributions), and stacked area handles that
+        # poorly.  We keep the raw sign for the hero summary below.
+        "contributions": [round(float(v), 2) for v in daily_total["implied_contributions"].tolist()],
+        "gains":         [round(float(v), 2) for v in daily_total["implied_gains"].tolist()],
+    }
+
+
+def _build_allocation(latest_per_account: pd.DataFrame):
+    """Today's allocation across all accounts: equity / option / cash."""
+    if latest_per_account.empty:
+        return {"equity": 0.0, "option": 0.0, "cash": 0.0}
+    return {
+        "equity": round(float(latest_per_account["equity_value"].sum()), 2),
+        "option": round(float(latest_per_account["option_value"].sum()), 2),
+        "cash":   round(float(latest_per_account["cash_value"].sum()),   2),
+    }
+
+
+def _build_allocation_year_ago(per_account_long: pd.DataFrame, today: date):
+    """Allocation at most-recent snapshot on-or-before today − 1 year, summed
+    across the user's accounts."""
+    if per_account_long.empty:
+        return None
+    target = today - timedelta(days=365)
+    target_ts = pd.Timestamp(target)
+
+    # Latest row per account on-or-before target
+    sub = per_account_long[per_account_long["_d"] <= target_ts]
+    if sub.empty:
+        return None
+    latest = sub.sort_values("_d").groupby("account").tail(1)
+    return {
+        "equity": round(float(latest["equity_value"].sum()), 2),
+        "option": round(float(latest["option_value"].sum()), 2),
+        "cash":   round(float(latest["cash_value"].sum()),   2),
+        "as_of":  str(target),
+    }
+
+
+# ------------------------------------------------------------------
+# Route
+# ------------------------------------------------------------------
+
+@app.route("/wealth")
+@login_required
+def wealth():
+    """High-level wealth dashboard."""
+    selected_account = (request.args.get("account", "") or "").strip()
+    user_accounts = _user_accounts_for_request(selected_account)
+
+    if is_admin(current_user.username):
+        accounts = []
+    else:
+        accounts = get_accounts_for_user(current_user.id) or []
+
+    hero = None
+    networth = {"dates": [], "values": []}
+    spy_series = {"dates": [], "values": []}
+    qqq_series = {"dates": [], "values": []}
+    contrib_gains = {"dates": [], "contributions": [], "gains": []}
+    alloc_now = {"equity": 0.0, "option": 0.0, "cash": 0.0}
+    alloc_year_ago = None
+    error = None
+    has_data = False
+
+    try:
+        client = get_bigquery_client()
+        wealth_df = client.query(
+            WEALTH_DAILY_QUERY.format(account_filter=_account_sql_and(user_accounts))
+        ).to_dataframe()
+        wealth_df = _filter_df_by_accounts(wealth_df, user_accounts)
+
+        if not wealth_df.empty:
+            has_data = True
+            wealth_df["_d"] = pd.to_datetime(wealth_df["date"])
+
+            # Aggregate across the user's accounts to a single per-day
+            # net-worth row.  Sums make sense for *_value and the
+            # cumulative_* columns.
+            daily_total = (
+                wealth_df.groupby("date", as_index=False)
+                         .agg(account_value=("account_value", "sum"),
+                              equity_value=("equity_value", "sum"),
+                              option_value=("option_value", "sum"),
+                              cash_value=("cash_value", "sum"),
+                              implied_contributions=("implied_contributions", "sum"),
+                              implied_gains=("implied_gains", "sum"))
+                         .sort_values("date")
+                         .reset_index(drop=True)
+            )
+
+            hero = _build_hero(daily_total[["date", "account_value"]])
+            networth = _build_networth_series(daily_total[["date", "account_value"]])
+            contrib_gains = _build_contrib_vs_gains(daily_total)
+
+            # Allocation now: latest row per account, summed.
+            latest_per_account = (
+                wealth_df.sort_values("_d").groupby("account").tail(1)
+            )
+            alloc_now = _build_allocation(latest_per_account)
+
+            today = daily_total["date"].iloc[-1]
+            if hasattr(today, "to_pydatetime"):
+                today = today.to_pydatetime().date()
+            elif hasattr(today, "date"):
+                today = today.date()
+            alloc_year_ago = _build_allocation_year_ago(wealth_df, today)
+
+            # Benchmark, anchored at the user's first snapshot date.
+            start_date = daily_total["date"].iloc[0]
+            cfg = None
+            try:
+                from google.cloud import bigquery as bq
+                cfg = bq.QueryJobConfig(query_parameters=[
+                    bq.ScalarQueryParameter("start_date", "DATE", start_date),
+                ])
+            except Exception:
+                cfg = None
+            bench_df = client.query(BENCHMARK_QUERY, job_config=cfg).to_dataframe()
+
+            spy_series = _build_benchmark_series(daily_total, bench_df, "SPY")
+            qqq_series = _build_benchmark_series(daily_total, bench_df, "QQQ")
+    except Exception as exc:
+        app.logger.warning("/wealth query failed: %s", exc)
+        error = "Could not load wealth data right now. Try again in a minute."
+
+    return render_template(
+        "wealth.html",
+        title="Wealth",
+        accounts=accounts,
+        selected_account=selected_account,
+        has_data=has_data,
+        hero=hero,
+        alloc_now=alloc_now,
+        alloc_year_ago=alloc_year_ago,
+        error=error,
+        # JSON payloads consumed by Chart.js inside the template
+        networth_json=json.dumps(networth),
+        spy_json=json.dumps(spy_series),
+        qqq_json=json.dumps(qqq_series),
+        contrib_gains_json=json.dumps(contrib_gains),
+        alloc_now_json=json.dumps(alloc_now),
+        alloc_year_ago_json=json.dumps(alloc_year_ago) if alloc_year_ago else "null",
+    )

--- a/dbt/models/marts/mart_wealth_daily.sql
+++ b/dbt/models/marts/mart_wealth_daily.sql
@@ -1,0 +1,176 @@
+{{ config(materialized='table') }}
+
+/*
+    Daily wealth + cumulative trading flow per (account, date).
+
+    Powers the /wealth page.
+
+    Built from two sources:
+      1. mart_account_equity_daily — actual snapshot account_value /
+         equity_value / option_value / cash_value (truth from Schwab).
+      2. stg_history — per-day options P&L cash flow + dividends.
+
+    "Implied contributions" is computed by *identity*, not measurement:
+
+        contributions(d) = account_value(d) − cumulative_trading_pnl(d)
+                                            − cumulative_dividends(d)
+
+    Schwab's CSV does not expose deposit/withdrawal rows in stg_history,
+    so this is the only honest way to back-out money-in.  When the trader
+    did not deposit anything, `contributions` will trend roughly flat.
+    When a deposit happened, it shows up as a step-up.
+
+    `gains` = account_value − contributions (the part that is *not*
+    money the trader put in).  Useful for the "money in vs gains"
+    stacked chart.
+
+    Tenancy: `account` column on every row.  Apps must scope by user's
+    accounts in SQL and Python.
+*/
+
+with daily_value as (
+    -- Account snapshot truth (option_value already separated from equity_value)
+    select
+        account,
+        date,
+        account_value,
+        equity_value,
+        option_value,
+        cash_value
+    from {{ ref('mart_account_equity_daily') }}
+),
+
+-- Per-day options realized cash flow (sells - buys, including expirations)
+options_pnl_daily as (
+    select
+        account,
+        trade_date as date,
+        sum(case when instrument_type in ('Call', 'Put') then amount else 0 end) as options_realized
+    from {{ ref('stg_history') }}
+    where trade_date is not null
+    group by 1, 2
+),
+
+-- Per-day dividend cash flow
+div_daily as (
+    select
+        account,
+        trade_date as date,
+        sum(case when action = 'dividend' then amount else 0 end) as dividends
+    from {{ ref('stg_history') }}
+    where trade_date is not null
+    group by 1, 2
+),
+
+-- Per-day equity buy/sell cash flow.  We treat (sells − buys) as realized
+-- equity P&L only AFTER summing across all days; on any single day buying
+-- 100 shares is just allocation, not a loss.
+equity_flow_daily as (
+    select
+        account,
+        trade_date as date,
+        sum(case when instrument_type = 'Equity'
+                  and action in ('equity_sell', 'equity_sell_short')
+                 then amount else 0 end)
+          + sum(case when instrument_type = 'Equity' and action = 'equity_buy'
+                     then amount else 0 end) as equity_net_flow
+    from {{ ref('stg_history') }}
+    where trade_date is not null
+    group by 1, 2
+),
+
+joined as (
+    select
+        d.account,
+        d.date,
+        d.account_value,
+        d.equity_value,
+        d.option_value,
+        d.cash_value,
+        coalesce(o.options_realized, 0)   as options_realized_today,
+        coalesce(dv.dividends, 0)         as dividends_today,
+        coalesce(ef.equity_net_flow, 0)   as equity_net_flow_today
+    from daily_value d
+    left join options_pnl_daily o
+        on d.account = o.account and d.date = o.date
+    left join div_daily dv
+        on d.account = dv.account and d.date = dv.date
+    left join equity_flow_daily ef
+        on d.account = ef.account and d.date = ef.date
+),
+
+-- Running totals.  We sum FROM the very first day forward — even days
+-- before the first snapshot — but only emit rows where account_value
+-- (the snapshot) actually exists.
+with_cumulative as (
+    select
+        account,
+        date,
+        account_value,
+        equity_value,
+        option_value,
+        cash_value,
+        options_realized_today,
+        dividends_today,
+        equity_net_flow_today,
+
+        sum(options_realized_today) over (
+            partition by account
+            order by date
+            rows between unbounded preceding and current row
+        ) as cumulative_options_pnl,
+
+        sum(dividends_today) over (
+            partition by account
+            order by date
+            rows between unbounded preceding and current row
+        ) as cumulative_dividends,
+
+        sum(equity_net_flow_today) over (
+            partition by account
+            order by date
+            rows between unbounded preceding and current row
+        ) as cumulative_equity_net_flow
+    from joined
+),
+
+final as (
+    select
+        account,
+        date,
+        account_value,
+        equity_value,
+        option_value,
+        cash_value,
+
+        cumulative_options_pnl,
+        cumulative_dividends,
+        cumulative_equity_net_flow,
+
+        -- Rough realized-trading-PnL proxy (cash from option closes
+        -- + dividends + equity net cash flow).  Used to back out
+        -- contributions; not a substitute for full P&L accounting.
+        cumulative_options_pnl + cumulative_dividends + cumulative_equity_net_flow
+            as cumulative_trading_cashflow,
+
+        -- IMPLIED contributions: residual after subtracting trading
+        -- cashflow from account_value.  When this jumps up between
+        -- two days with no trades, the trader almost certainly
+        -- deposited money.  When stable, no deposits.
+        account_value
+            - cumulative_options_pnl
+            - cumulative_dividends
+            - cumulative_equity_net_flow
+            as implied_contributions,
+
+        -- "gains" = the part of account_value that wasn't money the
+        -- trader put in.  account_value - implied_contributions.
+        cumulative_options_pnl
+            + cumulative_dividends
+            + cumulative_equity_net_flow
+            as implied_gains
+    from with_cumulative
+)
+
+select * from final
+order by account, date


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

A dedicated **/wealth** page that answers the boring-but-loved question every retail user opens a finance app for: *"is the line going up?"*  Lives separately from the Trading Mirror so `/weekly-review` stays process-first.

Plus the existing `default_route` preference now includes `wealth`, so any user can pick it as their post-login home page in **Profile → Preferences**.

### What's on the page

1. **Hero strip** — current total net worth + Today / Week / Month / YTD / All-time deltas.
2. **Net worth over time** — daily account value across all accounts, with SPY and QQQ toggleable as rebased overlays anchored at the user's first snapshot dollar value.
3. **Money in vs gains** — stacked area showing implied contributions vs implied gains.
4. **Allocation now** + **Allocation a year ago** — equity / options / cash donuts.

The account selector at the top of the page lets the user scope to any single account (mirrors the pattern on `/weekly-review`, `/positions`, etc.).

## Architecture

### dbt

New mart [`mart_wealth_daily.sql`](dbt/models/marts/mart_wealth_daily.sql), one row per `(account, date)`:

- `account_value`, `equity_value`, `option_value`, `cash_value` — pulled straight from [`mart_account_equity_daily`](dbt/models/marts/mart_account_equity_daily.sql) (broker truth from Schwab snapshots).
- `cumulative_options_pnl`, `cumulative_dividends`, `cumulative_equity_net_flow` — running sums of the matching cash flows from [`stg_history`](dbt/models/staging/stg_history.sql).
- `implied_contributions = account_value − cumulative_options_pnl − cumulative_dividends − cumulative_equity_net_flow`.
- `implied_gains` = the trading cashflow component (account_value − implied_contributions).

### Why "implied"

Schwab CSV exports don't include deposit/withdrawal line items, and the [`stg_history`](dbt/models/staging/stg_history.sql) action taxonomy has no `deposit` / `withdrawal` bucket. We back-out contributions by identity. Step-ups in the orange band on the chart are almost certainly real deposits; flat means the trader didn't add money. The footnote on the page makes this explicit. If/when transfer rows get ingested, we replace `implied_contributions` with the directly-measured value without changing the surface.

### Flask

[`app/wealth.py`](app/wealth.py) — single `/wealth` route, all aggregation in pandas after pulling from BQ. Hero deltas use most-recent snapshot on-or-before each anchor date (today−1, today−7, today−30, year-end of prior year, first snapshot). Benchmark series uses `merge_asof(direction="backward")` to forward-fill SPY/QQQ closes onto the trader's snapshot dates, then rebases to the trader's starting net-worth value.

### Settings → home page

`'wealth'` is added to `_ALLOWED_DEFAULT_ROUTE` ([`app/profile_community.py`](app/profile_community.py)) and `_LANDING` ([`app/auth.py`](app/auth.py)). The Profile preferences template iterates the allowed list, so the dropdown picks it up automatically.

## Tenancy ([`.cursor/rules/bigquery-tenant-isolation.mdc`](.cursor/rules/bigquery-tenant-isolation.mdc))

- `mart_wealth_daily` carries `account` on every row.
- `WEALTH_DAILY_QUERY` is scoped via `{account_filter}` (`AND account IN (...)` built from `get_accounts_for_user`).
- The resulting DataFrame passes through `_filter_df_by_accounts` before any aggregation or render — belt and suspenders.
- The benchmark query (SPY/QQQ from `stg_daily_prices`) is intentionally not account-scoped: those rows are public market data; only price symbols are exposed.

## Validation

- `dbt parse` passes.
- `sqlglot` BigQuery dialect parses `mart_wealth_daily.sql`.
- `ast.parse` clean on all touched Python files.
- Jinja parse clean on `wealth.html`.

## Suggested rollout

1. Merge → next nightly `bigquery_update.yml` builds `mart_wealth_daily`.
2. Eyeball `/wealth` for one account: does the contributions line behave sensibly across known deposit dates? If it spikes too aggressively from option-PnL day-to-day, we can switch `cumulative_options_pnl` to use a smoothed monthly bucket. Easy follow-up.
3. Optional: change the default for `default_route` for new signups to `wealth` if it tests well.

## What this does NOT do

- Does not change `/weekly-review`. Trading Mirror identity is intact.
- Does not introduce real-time pricing — uses end-of-day snapshots already in `mart_account_equity_daily`.
- Does not predict, recommend, or score. Per [`AGENTS.md`](AGENTS.md), wealth is *context*; the Mirror is *signal*.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4c56fbd-00da-41ac-bd4b-9f3494ffecd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4c56fbd-00da-41ac-bd4b-9f3494ffecd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

