### PR TITLE
Weekly Review: "Since you last looked" diff + Today reframe

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -187,6 +187,13 @@ def init_db():
         CREATE INDEX IF NOT EXISTS idx_community_posts_visibility_created
         ON community_posts (visibility, created_at DESC)
         """,
+        """
+        CREATE TABLE IF NOT EXISTS user_review_visits (
+            user_id        INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+            last_visit_at  TIMESTAMPTZ NOT NULL,
+            prev_visit_at  TIMESTAMPTZ
+        )
+        """,
     ]
     with get_conn() as conn:
         with conn.cursor() as cur:
@@ -672,6 +679,71 @@ def update_user_profile(user_id, **fields):
     except Exception as exc:
         _log.warning("update_user_profile failed: %s", exc)
         return False
+
+
+# ------------------------------------------------------------------
+# Review visit anchors  ("Since you last looked")
+#
+# We track two timestamps per user:
+#   prev_visit_at  → the visit BEFORE the current one (the one we diff against)
+#   last_visit_at  → the most recent visit (becomes prev on the next "real" visit)
+#
+# A "real" visit is one separated from last_visit_at by at least
+# REVIEW_VISIT_PROMOTE_GAP — otherwise rapid reloads would clobber the prev
+# anchor and make the diff strip useless.
+# ------------------------------------------------------------------
+from datetime import timedelta as _timedelta
+
+REVIEW_VISIT_PROMOTE_GAP = _timedelta(minutes=30)
+
+
+def get_review_visit(user_id):
+    """Return {'last_visit_at': dt, 'prev_visit_at': dt} or None if never visited."""
+    try:
+        row = fetch_one(
+            "SELECT last_visit_at, prev_visit_at FROM user_review_visits WHERE user_id = %s",
+            (user_id,),
+        )
+        return row
+    except Exception as exc:
+        _log.warning("get_review_visit failed: %s", exc)
+        return None
+
+
+def bump_review_visit(user_id, now):
+    """
+    Record a weekly-review visit. Debounced: if the prior last_visit_at is
+    within REVIEW_VISIT_PROMOTE_GAP, last_visit_at is NOT moved — that way a
+    burst of reloads doesn't reset the "since you last looked" anchor and
+    flatten the diff to nothing.
+
+    On a non-debounced visit, prior last_visit_at is rotated to prev_visit_at.
+
+    Returns the row state BEFORE the bump, so the route can use
+    prior['last_visit_at'] as the anchor to diff against.
+    """
+    prior = get_review_visit(user_id)
+    try:
+        if prior is None:
+            execute(
+                "INSERT INTO user_review_visits (user_id, last_visit_at, prev_visit_at) "
+                "VALUES (%s, %s, NULL) "
+                "ON CONFLICT (user_id) DO UPDATE SET last_visit_at = EXCLUDED.last_visit_at",
+                (user_id, now),
+            )
+        else:
+            last = prior.get("last_visit_at")
+            if last is None or (now - last) >= REVIEW_VISIT_PROMOTE_GAP:
+                execute(
+                    "UPDATE user_review_visits "
+                    "SET prev_visit_at = last_visit_at, last_visit_at = %s "
+                    "WHERE user_id = %s",
+                    (now, user_id),
+                )
+            # else: debounced reload, leave last_visit_at alone
+    except Exception as exc:
+        _log.warning("bump_review_visit failed: %s", exc)
+    return prior
 
 
 def get_user_by_username(username):

--- a/app/templates/weekly_review.html
+++ b/app/templates/weekly_review.html
@@ -48,6 +48,75 @@
         color: rgba(255,255,255,.35);
     }
 
+    /* ── Since you last looked ── */
+    .since-card {
+        background: linear-gradient(135deg, #fffaf0 0%, #fff 100%);
+        border: 1px solid #fde68a;
+        border-radius: 14px;
+        padding: 1.1rem 1.4rem;
+        margin-bottom: 1.25rem;
+        box-shadow: 0 1px 8px rgba(234, 179, 8, .08);
+    }
+    .since-kicker {
+        font-size: .68rem;
+        text-transform: uppercase;
+        letter-spacing: 1.1px;
+        color: #b45309;
+        font-weight: 700;
+        margin-bottom: .2rem;
+        display: flex;
+        align-items: center;
+        gap: .4rem;
+    }
+    .since-kicker .since-dot {
+        width: 7px; height: 7px; border-radius: 50%;
+        background: #f59e0b;
+        animation: since-pulse 2.2s infinite;
+    }
+    @keyframes since-pulse {
+        0%, 100% { opacity: .5; }
+        50%      { opacity: 1; }
+    }
+    .since-headline {
+        font-size: 1rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin: 0 0 .65rem;
+    }
+    .since-row {
+        display: flex; flex-wrap: wrap; gap: .5rem .9rem;
+        font-size: .85rem;
+        margin-bottom: .35rem;
+    }
+    .since-row:last-child { margin-bottom: 0; }
+    .since-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: .35rem;
+        padding: .25rem .65rem;
+        border-radius: 14px;
+        background: #fff;
+        border: 1px solid #e5e7eb;
+        font-size: .8rem;
+        text-decoration: none;
+        color: inherit;
+        white-space: nowrap;
+    }
+    .since-chip:hover { border-color: #cbd5e1; color: inherit; text-decoration: none; }
+    .since-chip .sym { font-weight: 700; }
+    .since-chip.up   { border-color: rgba(25,135,84,.3);  background: rgba(25,135,84,.05); }
+    .since-chip.down { border-color: rgba(220,53,69,.3);  background: rgba(220,53,69,.05); }
+    .since-chip.warn { border-color: rgba(234,179,8,.4);  background: rgba(234,179,8,.08); }
+    .since-section-label {
+        font-size: .68rem;
+        text-transform: uppercase;
+        letter-spacing: .6px;
+        color: #94a3b8;
+        font-weight: 600;
+        margin-right: .25rem;
+        align-self: center;
+    }
+
     /* ── Account snapshot ── */
     .snapshot-section { padding: 1.25rem 1.75rem; }
     .snapshot-row {
@@ -414,7 +483,7 @@
         <a href="{{ url_for('weekly_review', mode='monday', account=selected_account) if selected_account else url_for('weekly_review', mode='monday') }}"
            class="mode-pill {% if mode == 'monday' %}active{% endif %}">Monday Check</a>
         <a href="{{ url_for('weekly_review', mode='midweek', account=selected_account) if selected_account else url_for('weekly_review', mode='midweek') }}"
-           class="mode-pill {% if mode == 'midweek' %}active{% endif %}">Mid-Week</a>
+           class="mode-pill {% if mode == 'midweek' %}active{% endif %}">Today</a>
     </div>
 
     {% if narrative %}
@@ -436,6 +505,110 @@
         {% endif %}
     </div>
 </div>
+
+{# ════════════════════════════════════
+   SINCE YOU LAST LOOKED (daily-pull diff)
+
+   Renders only when there's something genuinely new vs the user's previous
+   visit: stock moves on open positions, trades that opened/closed, options
+   that newly entered the 7-day expiry window, or options that just went ITM.
+   ════════════════════════════════════ #}
+{% if since_last_looked %}
+{% set sll = since_last_looked %}
+<div class="since-card">
+    <div class="since-kicker">
+        <span class="since-dot"></span>
+        Since you last looked
+    </div>
+    <p class="since-headline">
+        {% if sll.is_first_visit %}
+        What changed yesterday
+        {% else %}
+        What changed since {{ sll.time_ago }}
+        {% endif %}
+    </p>
+
+    {# Stock moves on open positions #}
+    {% if sll.moves %}
+    <div class="since-row">
+        <span class="since-section-label">Moves</span>
+        {% for m in sll.moves %}
+        <a class="since-chip {% if m.positive %}up{% else %}down{% endif %}"
+           href="{{ url_for('position_detail', symbol=m.symbol) }}"
+           title="From ${{ '%.2f' % m.prior_price }} to ${{ '%.2f' % m.current_price }}">
+            <span class="sym">{{ m.symbol }}</span>
+            <span>{{ '+' if m.positive else '' }}{{ '%.2f' % m.delta_pct }}%</span>
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {# Newly in the money — strongest signal, surface up top with stronger styling #}
+    {% if sll.newly_itm %}
+    <div class="since-row">
+        <span class="since-section-label">Newly ITM</span>
+        {% for opt in sll.newly_itm %}
+        <a class="since-chip warn"
+           href="{{ url_for('position_detail', symbol=opt.symbol) }}"
+           title="Stock moved across the {{ '%.2f' % opt.strike }} strike since your last visit">
+            <span class="sym">{{ opt.symbol }}</span>
+            <span>{{ opt.option_type|lower }} {{ '%.0f' % opt.strike }}</span>
+            {% if opt.days_to_exp is not none %}
+            <span class="text-muted">{{ opt.days_to_exp }}d</span>
+            {% endif %}
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {# Options that just entered the 7-day expiry window #}
+    {% if sll.newly_near_expiry %}
+    <div class="since-row">
+        <span class="since-section-label">Now expiring soon</span>
+        {% for opt in sll.newly_near_expiry %}
+        <a class="since-chip"
+           href="{{ url_for('position_detail', symbol=opt.symbol) }}">
+            <span class="sym">{{ opt.symbol }}</span>
+            <span>{{ opt.option_type|lower }} {{ '%.0f' % (opt.strike or 0) }}</span>
+            <span class="text-muted">{{ opt.days_to_exp }}d</span>
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {# Trades that closed since #}
+    {% if sll.closed_trades %}
+    <div class="since-row">
+        <span class="since-section-label">Closed</span>
+        {% for t in sll.closed_trades %}
+        <a class="since-chip {% if t.positive %}up{% else %}down{% endif %}"
+           href="{{ url_for('position_detail', symbol=t.symbol) }}">
+            <span class="sym">{{ t.symbol }}</span>
+            {% if t.total_pnl is not none %}
+            <span>{{ '+' if t.positive else '' }}${{ '{:,.0f}'.format(t.total_pnl) }}</span>
+            {% endif %}
+            <span class="text-muted">{{ t.close_date }}</span>
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
+
+    {# Trades that opened since #}
+    {% if sll.opened_trades %}
+    <div class="since-row">
+        <span class="since-section-label">Opened</span>
+        {% for t in sll.opened_trades %}
+        <a class="since-chip"
+           href="{{ url_for('position_detail', symbol=t.symbol) }}">
+            <span class="sym">{{ t.symbol }}</span>
+            {% if t.strategy %}<span class="text-muted">{{ t.strategy }}</span>{% endif %}
+            <span class="text-muted">{{ t.open_date }}</span>
+        </a>
+        {% endfor %}
+    </div>
+    {% endif %}
+</div>
+{% endif %}
 
 {# ════════════════════════════════════
    ACCOUNT SNAPSHOT (daily hook)

--- a/app/weekly_review.py
+++ b/app/weekly_review.py
@@ -20,6 +20,8 @@ from app.models import (
     get_published_trade_fingerprints,
     get_user_profile,
     trade_fingerprint,
+    get_review_visit,
+    bump_review_visit,
 )
 from google.cloud import bigquery
 from concurrent.futures import ThreadPoolExecutor
@@ -543,6 +545,278 @@ def _detect_patterns(client, account_filter, week_start, week_end):
     return patterns
 
 
+# ──────────────────────────────────────────────────────────────────
+# "Since you last looked" — daily pull hook
+# ──────────────────────────────────────────────────────────────────
+#
+# The page is Today-first. We diff the current world against a snapshot of
+# the world at the user's previous visit (or yesterday if this is their first
+# real visit). Output is ALWAYS in the user's accounts only — every query
+# below is account-scoped at the SQL level (per BigQuery tenant-isolation
+# rules) and any DataFrame is filtered before merge.
+
+# Prior closes (one row per symbol) at the most recent close strictly BEFORE
+# the cutoff date. Used to compute "since you last looked" stock moves.
+PRIOR_CLOSE_QUERY = """
+WITH ranked AS (
+    SELECT symbol, date, close_price,
+           ROW_NUMBER() OVER (PARTITION BY symbol ORDER BY date DESC) AS rn
+    FROM `ccwj-dbt.analytics.stg_daily_prices`
+    WHERE symbol IN UNNEST(@symbols)
+      AND date <= @cutoff_date
+      AND close_price IS NOT NULL AND close_price > 0
+)
+SELECT symbol, date AS prior_date, close_price AS prior_close
+FROM ranked
+WHERE rn = 1
+"""
+
+# Trades that closed since the prior visit (date-grain — within the user's
+# account scope). Small list intended for the "since" strip.
+TRADES_CLOSED_SINCE_QUERY = """
+SELECT account, symbol, strategy, trade_symbol, close_date, total_pnl
+FROM `ccwj-dbt.analytics.int_strategy_classification`
+WHERE status = 'Closed'
+  AND close_date >= @since_date
+  AND close_date <= @today_date
+  AND num_trades > 0
+  {account_filter}
+ORDER BY close_date DESC, ABS(total_pnl) DESC
+LIMIT 5
+"""
+
+# Trades that opened since the prior visit.
+TRADES_OPENED_SINCE_QUERY = """
+SELECT account, symbol, strategy, open_date
+FROM `ccwj-dbt.analytics.int_strategy_classification`
+WHERE open_date >= @since_date
+  AND open_date <= @today_date
+  AND num_trades > 0
+  {account_filter}
+ORDER BY open_date DESC
+LIMIT 10
+"""
+
+
+def _humanize_gap(gap):
+    """Render a timedelta as 'N hours/days/weeks ago' for a friendly label."""
+    if gap is None:
+        return "your last visit"
+    total_seconds = int(gap.total_seconds())
+    if total_seconds < 60:
+        return "moments ago"
+    minutes = total_seconds // 60
+    if minutes < 60:
+        return f"{minutes} minute{'s' if minutes != 1 else ''} ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours} hour{'s' if hours != 1 else ''} ago"
+    days = hours // 24
+    if days < 7:
+        return f"{days} day{'s' if days != 1 else ''} ago"
+    weeks = days // 7
+    if weeks < 5:
+        return f"{weeks} week{'s' if weeks != 1 else ''} ago"
+    return "a while ago"
+
+
+def _since_last_looked(client, account_filter, prev_visit_dt, today, today_strip,
+                       expiring_options, user_tz):
+    """
+    Build the "Since you last looked" diff card.
+
+    Strategy:
+      • Anchor date = the calendar date of prev_visit_dt in the user's TZ
+        (or today - 1 day if there's no prior visit yet — first real visit
+        still gets a useful "since yesterday" view).
+      • Stock moves: per open-position symbol, compare today's latest close
+        vs the close on/before anchor_date (PRIOR_CLOSE_QUERY).
+      • Trades closed / opened since anchor (account-scoped).
+      • Newly-near expirations: options now ≤ 7 days out that were > 7 days
+        out at anchor_date (cheap heuristic: expiry - anchor_date > 7).
+
+    Returns a dict consumable by the template, or None if there's nothing
+    interesting to show.
+    """
+    try:
+        if prev_visit_dt is not None:
+            tz = ZoneInfo(user_tz) if user_tz else ZoneInfo("America/New_York")
+            anchor_date = prev_visit_dt.astimezone(tz).date()
+            gap = datetime.now(tz) - prev_visit_dt.astimezone(tz)
+            time_ago = _humanize_gap(gap)
+            is_first_visit = False
+        else:
+            anchor_date = today - timedelta(days=1)
+            time_ago = "yesterday"
+            is_first_visit = True
+
+        # Don't diff against today itself — nothing changes.
+        if anchor_date >= today:
+            anchor_date = today - timedelta(days=1)
+
+        symbols = sorted({
+            (s.get("symbol") or "").upper()
+            for s in (today_strip or [])
+            if s.get("symbol")
+        })
+
+        moves = []
+        if symbols:
+            try:
+                cfg = bigquery.QueryJobConfig(query_parameters=[
+                    bigquery.ArrayQueryParameter("symbols", "STRING", symbols),
+                    bigquery.ScalarQueryParameter("cutoff_date", "DATE", anchor_date),
+                ])
+                df = client.query(PRIOR_CLOSE_QUERY, job_config=cfg).to_dataframe()
+                # Map: symbol → prior_close  (PRIOR_CLOSE_QUERY is symbol-only,
+                # not user-data; account scoping doesn't apply.)
+                prior_map = {}
+                for _, row in df.iterrows():
+                    sym = str(row["symbol"]).upper()
+                    prior_map[sym] = float(row["prior_close"])
+
+                for s in today_strip:
+                    sym = (s.get("symbol") or "").upper()
+                    cur_price = s.get("price")
+                    prior = prior_map.get(sym)
+                    if not sym or cur_price is None or prior is None or prior <= 0:
+                        continue
+                    delta = float(cur_price) - prior
+                    pct = (delta / prior) * 100.0
+                    if abs(pct) < 0.5:
+                        continue  # too small to bother surfacing
+                    moves.append({
+                        "symbol": sym,
+                        "prior_price": round(prior, 2),
+                        "current_price": round(float(cur_price), 2),
+                        "delta": round(delta, 2),
+                        "delta_pct": round(pct, 2),
+                        "positive": delta >= 0,
+                    })
+                moves.sort(key=lambda m: abs(m["delta_pct"]), reverse=True)
+                moves = moves[:5]
+            except Exception as exc:
+                if app.debug:
+                    app.logger.warning("Since-last-looked prior closes failed: %s", exc)
+
+        # Trades opened / closed since anchor — strictly account-scoped.
+        opened = []
+        closed = []
+        try:
+            cfg = bigquery.QueryJobConfig(query_parameters=[
+                bigquery.ScalarQueryParameter("since_date", "DATE", anchor_date),
+                bigquery.ScalarQueryParameter("today_date", "DATE", today),
+            ])
+            closed_df = client.query(
+                TRADES_CLOSED_SINCE_QUERY.format(account_filter=account_filter),
+                job_config=cfg,
+            ).to_dataframe()
+            for _, row in closed_df.iterrows():
+                pnl = row.get("total_pnl")
+                pnl_v = float(pnl) if pnl is not None else None
+                cd = row.get("close_date")
+                cd_s = cd.isoformat() if hasattr(cd, "isoformat") else str(cd)[:10]
+                closed.append({
+                    "symbol": str(row.get("symbol") or ""),
+                    "strategy": str(row.get("strategy") or ""),
+                    "trade_symbol": str(row.get("trade_symbol") or ""),
+                    "close_date": cd_s,
+                    "total_pnl": pnl_v,
+                    "positive": (pnl_v is not None and pnl_v >= 0),
+                })
+
+            opened_df = client.query(
+                TRADES_OPENED_SINCE_QUERY.format(account_filter=account_filter),
+                job_config=cfg,
+            ).to_dataframe()
+            for _, row in opened_df.iterrows():
+                od = row.get("open_date")
+                od_s = od.isoformat() if hasattr(od, "isoformat") else str(od)[:10]
+                opened.append({
+                    "symbol": str(row.get("symbol") or ""),
+                    "strategy": str(row.get("strategy") or ""),
+                    "open_date": od_s,
+                })
+        except Exception as exc:
+            if app.debug:
+                app.logger.warning("Since-last-looked trades query failed: %s", exc)
+
+        # Newly-near expirations: now in the 7-day window AND were further out
+        # at anchor (expiry - anchor > 7 days). Uses already-computed list.
+        newly_near_expiry = []
+        for opt in (expiring_options or []):
+            try:
+                exp_str = opt.get("expiry") or ""
+                if not exp_str:
+                    continue
+                exp_d = date.fromisoformat(str(exp_str)[:10])
+            except Exception:
+                continue
+            days_now = (exp_d - today).days
+            days_at_anchor = (exp_d - anchor_date).days
+            if 0 <= days_now <= 7 and days_at_anchor > 7:
+                newly_near_expiry.append({
+                    "symbol": opt.get("symbol"),
+                    "trade_symbol": opt.get("trade_symbol"),
+                    "option_type": opt.get("option_type"),
+                    "strike": opt.get("strike"),
+                    "expiry": exp_str,
+                    "days_to_exp": days_now,
+                    "itm": opt.get("itm"),
+                })
+
+        # Newly-ITM options: ITM now AND would have been OTM/ATM at anchor
+        # (cheap proxy: stock_price moved across strike since anchor based on
+        # the same prior_map we built for today_strip, falling back to
+        # stock_price on the option row if symbol isn't in the strip).
+        prior_map_for_opts = {m["symbol"]: m["prior_price"] for m in moves}
+        newly_itm = []
+        for opt in (expiring_options or []):
+            sym = (opt.get("symbol") or "").upper()
+            strike = opt.get("strike") or 0
+            opt_type = opt.get("option_type") or ""
+            cur_stock = opt.get("stock_price") or 0
+            if not opt.get("itm") or not strike or not cur_stock:
+                continue
+            prior_stock = prior_map_for_opts.get(sym)
+            if prior_stock is None:
+                continue
+            was_itm_then = (
+                (opt_type == "Call" and prior_stock >= strike) or
+                (opt_type == "Put" and prior_stock <= strike)
+            )
+            if not was_itm_then:
+                newly_itm.append({
+                    "symbol": sym,
+                    "trade_symbol": opt.get("trade_symbol"),
+                    "option_type": opt_type,
+                    "strike": strike,
+                    "expiry": opt.get("expiry"),
+                    "days_to_exp": opt.get("days_to_exp"),
+                    "prior_stock": prior_stock,
+                    "current_stock": cur_stock,
+                })
+
+        has_anything = bool(moves or opened or closed or newly_near_expiry or newly_itm)
+        if not has_anything:
+            return None
+
+        return {
+            "time_ago": time_ago,
+            "anchor_date": anchor_date.isoformat(),
+            "is_first_visit": is_first_visit,
+            "moves": moves,
+            "opened_trades": opened,
+            "closed_trades": closed,
+            "newly_near_expiry": newly_near_expiry,
+            "newly_itm": newly_itm,
+        }
+    except Exception as exc:
+        if app.debug:
+            app.logger.warning("_since_last_looked failed: %s", exc)
+        return None
+
+
 def _build_narrative(mode, review, prev_review, behavior_mirror, market,
                      today, week_start, trading_days=0, market_session=None):
     """Generate a dynamic hero headline + subtitle from actual data."""
@@ -666,27 +940,32 @@ def _build_narrative(mode, review, prev_review, behavior_mirror, market,
         return {"headline": headline, "subtitle": subtitle}
 
     elif mode == "midweek":
+        # "Today" framing — forward-looking, not a recap. The weekly stats are
+        # context underneath; the headline answers "what's live right now".
         try:
-            days_in = max(1, (today - week_start).days + 1)
-        except TypeError:
-            days_in = 1
-        td_label = f"{trading_days} trading day{'s' if trading_days != 1 else ''}" if trading_days else f"Day {days_in}"
+            day_name = today.strftime("%A")
+        except Exception:
+            day_name = "Today"
         if trades_closed > 0:
             sign = "+" if total_pnl >= 0 else ""
             headline = (
-                f"{td_label} \u00b7 {trades_closed} closed \u00b7 "
+                f"{day_name} \u00b7 {trades_closed} closed this week \u00b7 "
                 f"{sign}${abs(total_pnl):,.0f} so far"
             )
         else:
-            headline = f"{td_label} \u00b7 No closed trades yet"
+            headline = f"{day_name} \u00b7 Nothing closed this week yet"
         prefix = ""
         if market_session:
             st = market_session.get("state")
-            if st == "weekend":
-                prefix = "U.S. markets are closed (weekend). "
+            if st == "open":
+                prefix = "Markets are open. "
+            elif st == "weekend":
+                prefix = "Markets are closed (weekend). "
             elif st == "pre_market":
                 prefix = "Before the U.S. open. "
-        subtitle = prefix + "Mid-week check. Are you trading your plan, or reacting to the market?"
+            elif st == "after_hours":
+                prefix = "After the U.S. close. "
+        subtitle = prefix + "Here's what's live, what just changed, and what's coming up."
         return {
             "headline": headline,
             "subtitle": subtitle,
@@ -982,8 +1261,23 @@ def weekly_review():
 
     from_upload = request.args.get("from_upload") == "1"
 
+    # ── Visit anchors for "Since you last looked" ──
+    # bump_review_visit returns the row state BEFORE this request and
+    # debounces rapid reloads, so prior_visit['last_visit_at'] is literally
+    # "the time of your previous distinct visit" — what we want to diff
+    # against. None means this is the user's first visit ever.
+    prior_visit = bump_review_visit(current_user.id, datetime.now(ZoneInfo("UTC")))
+    since_anchor_dt = prior_visit.get("last_visit_at") if prior_visit else None
+
+    # Title leans on mode: "Today" pulls people in daily; "Friday Review"
+    # is the recap; "Monday Check" frames the start of week.
+    _titles = {
+        "friday":  "Friday Review",
+        "monday":  "Monday Check",
+        "midweek": "Today",
+    }
     context = {
-        "title": "Weekly Review",
+        "title": _titles.get(mode, "Weekly Review"),
         "mode": mode,
         "week_start": this_week,
         "week_end": this_week + timedelta(days=6),
@@ -1010,6 +1304,7 @@ def weekly_review():
         "strategy_breakdown_week": [],
         "community_profile_visibility": "private",
         "community_publish_ready": False,
+        "since_last_looked": None,
     }
 
     try:
@@ -1538,6 +1833,22 @@ def weekly_review():
         except Exception as e:
             if app.debug:
                 app.logger.warning("Open positions query failed: %s", e)
+
+        # ── Process: Since you last looked (daily-pull diff) ──
+        context["since_last_looked"] = None
+        try:
+            context["since_last_looked"] = _since_last_looked(
+                client=client,
+                account_filter=account_filter,
+                prev_visit_dt=since_anchor_dt,
+                today=today,
+                today_strip=context.get("today_strip", []),
+                expiring_options=context.get("expiring_options", []),
+                user_tz=user_tz,
+            )
+        except Exception as e:
+            if app.debug:
+                app.logger.warning("Since-last-looked failed: %s", e)
 
         # ── Process: Position Impact (stock movement vs option P&L) ──
         context["position_impact"] = []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this is

A first slice of the "make Weekly Review pull people in daily" work. Two changes, both opt-in (no behavior changes for users who don't load the page):

### 1. "Since you last looked" diff card

A new card at the top of `/weekly-review`, above the snapshot, that renders **only when there's something genuinely new** since the user's previous distinct visit. Sections (each only shown if non-empty):

- **Moves** — stock moves on currently-open positions, ≥0.5% threshold, sorted by magnitude (top 5).
- **Newly ITM** — options where the underlying crossed the strike since the anchor. Strongest signal, surfaced with warning styling.
- **Now expiring soon** — options that just entered the 7-day expiry window.
- **Closed / Opened** — trades that closed or opened since the anchor.

All chips link straight to `/position/<symbol>` so the diff is also a navigation surface.

### 2. "Today" reframe of the mid-week mode

- Mode pill renamed `Mid-Week` → `Today`.
- Headline reads forward (`Tuesday · 3 closed this week · +$420 so far`) instead of backward (`Day 2 · ...`).
- Subtitle adapts to market session (`Markets are open. Here's what's live, what just changed, and what's coming up.`).
- Page `<title>` follows the mode (`Today` / `Friday Review` / `Monday Check`).

Friday Review and Monday Check shapes are unchanged. Friday still owns the recap.

## How the visit anchor works

New table `user_review_visits (user_id, last_visit_at, prev_visit_at)`. On every weekly-review GET:

1. We read the prior row and use `prior.last_visit_at` as the diff anchor.
2. We bump the row, but **debounced**: if the prior visit is within 30 minutes, `last_visit_at` is left alone so a burst of reloads doesn't flatten the diff window. On a non-debounced visit, the old `last_visit_at` is rotated to `prev_visit_at`.
3. First-ever visit falls back to `today - 1 day` for the anchor so the first impression isn't an empty card.

## BigQuery / tenant isolation

Per `.cursor/rules/bigquery-tenant-isolation.mdc`:

- `TRADES_CLOSED_SINCE_QUERY` and `TRADES_OPENED_SINCE_QUERY` both include `{account_filter}` and run against `int_strategy_classification`, which has `account`. Same pattern as the existing `OPENS_THIS_WEEK_QUERY`.
- `PRIOR_CLOSE_QUERY` reads from `stg_daily_prices` (symbol-only market data, no per-user rows) — same as the existing `MARKET_PERF_QUERY` and `WEEKLY_STOCK_MOVEMENT_QUERY`. The symbols passed in are derived from the already-account-scoped `today_strip`, so we never accidentally request prices for a symbol the user doesn't hold.

No DataFrame merges that would cross tenant boundaries.

## Out of scope (intentionally)

- Daily / weekly recap email (the other half of the conversation that produced this). Tracked separately so we can validate the in-app diff first.
- Bigger structural reframe (e.g. moving Today Strip above the snapshot in non-Friday modes). Did the cheap, reversible change first.
- A new dbt mart for the visit diff. Right now this is two lightweight runtime queries; if it sticks we can move the heavier parts to dbt.

## Files changed

- `app/models.py` — new `user_review_visits` table + `get_review_visit` / `bump_review_visit` helpers.
- `app/weekly_review.py` — `_since_last_looked()`, three new query strings, route wiring, and the "Today" narrative + page title changes.
- `app/templates/weekly_review.html` — new card markup + CSS, mode pill rename.

## How to test

1. Open `/weekly-review` once — first visit, you should see the card with a `Since yesterday` headline (or no card if literally nothing changed in the last 24h, which is rare for an active account).
2. Wait >30 min, hit it again — anchor rotates, you'll see a card framed against the previous "real" visit.
3. Reload within 30 min — the anchor doesn't move, so the diff stays meaningful instead of going empty.
4. Visit `/weekly-review?mode=midweek` — pill should say "Today", subtitle should reflect current market session.

No DB migration script needed: `init_db()` runs `CREATE TABLE IF NOT EXISTS user_review_visits` on app startup, same pattern as the rest of the schema.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e5848ed-1d52-4d35-ba25-7c20cdc6443d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e5848ed-1d52-4d35-ba25-7c20cdc6443d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

