### PR TITLE
Rename "industry" to "subsector" across the product

### DIFF
--- a/.github/workflows/bigquery_update.yml
+++ b/.github/workflows/bigquery_update.yml
@@ -43,11 +43,11 @@ jobs:
           cp dbt/profiles.yml ~/.dbt/profiles.yml
           echo '${{ secrets.DBT_KEYFILE_JSON }}' > ~/.dbt/keyfile.json
 
-      # Sector / industry: refresh BEFORE the first dbt build so
+      # Sector / subsector: refresh BEFORE the first dbt build so
       # stg_symbol_metadata (and downstream marts that join it) have a real
       # source table to read from. Uses the previous run's stg_history for
       # the symbol list, which is fine — sectors don't change daily.
-      - name: Refresh symbol metadata (sector / industry)
+      - name: Refresh symbol metadata (sector / subsector)
         run: python scripts/refresh_symbol_metadata.py
         continue-on-error: true
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -320,7 +320,7 @@ ERROR_DEFAULTS = dict(
     accounts=[],
     strategies=[],
     symbols=[],
-    industries=[],
+    subsectors=[],
     sectors=[],
     user_accounts=[],
     status_counts={"Open": 0, "Closed": 0, "Mixed": 0},
@@ -328,7 +328,7 @@ ERROR_DEFAULTS = dict(
     selected_strategy="",
     selected_statuses=[],
     selected_symbol="",
-    selected_industry="",
+    selected_subsector="",
     selected_sector="",
     selected_start_date="",
     selected_end_date="",
@@ -622,7 +622,11 @@ def positions():
     # full book unless they explicitly narrow it.
     selected_statuses = request.args.getlist("status")
     selected_symbol = request.args.get("symbol", "")
-    selected_industry = request.args.get("industry", "")
+    # 'subsector' is the new param; 'industry' is the pre-rename alias and is
+    # still accepted so any old bookmarks / external links keep working.
+    selected_subsector = (
+        request.args.get("subsector", "") or request.args.get("industry", "")
+    )
     selected_sector = request.args.get("sector", "")
     selected_start_date = request.args.get("start_date", "")
     selected_end_date = request.args.get("end_date", "")
@@ -686,9 +690,9 @@ def positions():
     accounts = sorted(df["account"].dropna().unique())
     strategies = sorted(df["strategy"].dropna().unique())
     symbols = sorted(df["symbol"].dropna().unique())
-    industries = (
-        sorted(df["industry"].dropna().unique())
-        if "industry" in df.columns else []
+    subsectors = (
+        sorted(df["subsector"].dropna().unique())
+        if "subsector" in df.columns else []
     )
     sectors = (
         sorted(df["sector"].dropna().unique())
@@ -711,8 +715,8 @@ def positions():
         filtered = filtered[filtered["status"].isin(selected_statuses)]
     if selected_symbol:
         filtered = filtered[filtered["symbol"] == selected_symbol]
-    if selected_industry and "industry" in filtered.columns:
-        filtered = filtered[filtered["industry"] == selected_industry]
+    if selected_subsector and "subsector" in filtered.columns:
+        filtered = filtered[filtered["subsector"] == selected_subsector]
     if selected_sector and "sector" in filtered.columns:
         filtered = filtered[filtered["sector"] == selected_sector]
 
@@ -754,8 +758,8 @@ def positions():
     # 7. Symbol-level summary (grouped by account + symbol)
     # ------------------------------------------------------------------
     if not filtered.empty:
-        # Carry sector / industry through the symbol-level rollup. Each
-        # (account, symbol) maps to a single sector/industry, so 'first' is
+        # Carry sector / subsector through the symbol-level rollup. Each
+        # (account, symbol) maps to a single sector/subsector, so 'first' is
         # safe and fast.
         agg_kwargs = dict(
             total_pnl=("total_pnl", "sum"),
@@ -772,8 +776,8 @@ def positions():
         )
         if "sector" in filtered.columns:
             agg_kwargs["sector"] = ("sector", "first")
-        if "industry" in filtered.columns:
-            agg_kwargs["industry"] = ("industry", "first")
+        if "subsector" in filtered.columns:
+            agg_kwargs["subsector"] = ("subsector", "first")
         symbol_agg = (
             filtered.groupby(["account", "symbol"])
             .agg(**agg_kwargs)
@@ -833,7 +837,7 @@ def positions():
         accounts=accounts,
         strategies=strategies,
         symbols=symbols,
-        industries=industries,
+        subsectors=subsectors,
         sectors=sectors,
         user_accounts=accounts,
         status_counts=status_counts,
@@ -841,7 +845,7 @@ def positions():
         selected_strategy=selected_strategy,
         selected_statuses=selected_statuses,
         selected_symbol=selected_symbol,
-        selected_industry=selected_industry,
+        selected_subsector=selected_subsector,
         selected_sector=selected_sector,
         selected_start_date=selected_start_date,
         selected_end_date=selected_end_date,
@@ -1527,7 +1531,7 @@ def position_detail(symbol):
             chart_data_json="{}",
             has_underlying_price=False,
             symbol_sector="",
-            symbol_industry="",
+            symbol_subsector="",
             symbol_company="",
         )
 
@@ -2337,7 +2341,7 @@ def position_detail(symbol):
     else:
         all_accounts = []
 
-    # Sector / industry: take the first non-Unknown value we can find from
+    # Sector / subsector: take the first non-Unknown value we can find from
     # either summary or current. Both sources are joined to stg_symbol_metadata
     # in dbt, so they should agree — falling through is just defensive.
     def _first_nonempty(df_, col):
@@ -2353,7 +2357,7 @@ def position_detail(symbol):
         return vals.iloc[0]
 
     symbol_sector = _first_nonempty(summary_df, "sector") or _first_nonempty(current_df, "sector")
-    symbol_industry = _first_nonempty(summary_df, "industry") or _first_nonempty(current_df, "industry")
+    symbol_subsector = _first_nonempty(summary_df, "subsector") or _first_nonempty(current_df, "subsector")
     symbol_company = _first_nonempty(summary_df, "company_name") or _first_nonempty(current_df, "company_name")
 
     return render_template(
@@ -2375,7 +2379,7 @@ def position_detail(symbol):
         accounts=all_accounts,
         selected_account=selected_account,
         symbol_sector=symbol_sector,
-        symbol_industry=symbol_industry,
+        symbol_subsector=symbol_subsector,
         symbol_company=symbol_company,
     )
 
@@ -3743,18 +3747,21 @@ def _build_strategy_time_chart(strat_df):
 
 
 # ======================================================================
-# Industries  (/industries)
+# Sectors  (/sectors)
 # ======================================================================
 #
-# Sector / industry rollup of positions_summary, scoped to the logged-in
-# user's accounts. Powers the new "Industries" page in the Portfolio nav.
+# Sector / subsector rollup of positions_summary, scoped to the logged-in
+# user's accounts. Powers the "Sectors" page in the Portfolio nav.
+# (Originally /industries — renamed to standardize on the finance term
+# "sector → subsector" hierarchy. The /industries URL still resolves via
+# a redirect for old bookmarks.)
 # Tenancy: positions_summary is multi-tenant -> we MUST scope the SQL with
 # _account_sql_and AND filter the resulting DataFrame with
 # _filter_df_by_accounts before aggregating, per
 # .cursor/rules/bigquery-tenant-isolation.mdc.
 # ----------------------------------------------------------------------
 
-INDUSTRIES_QUERY = """
+SECTORS_QUERY = """
     SELECT
         account,
         symbol,
@@ -3770,7 +3777,7 @@ INDUSTRIES_QUERY = """
         num_winners,
         num_losers,
         sector,
-        industry,
+        subsector,
         company_name
     FROM `ccwj-dbt.analytics.positions_summary`
     WHERE 1=1
@@ -3780,7 +3787,15 @@ INDUSTRIES_QUERY = """
 
 @app.route("/industries")
 @login_required
-def industries():
+def industries_legacy():
+    """Backward-compatible redirect for the old /industries URL. The page
+    moved to /sectors when we renamed industry → subsector."""
+    return redirect(url_for("sectors", **request.args.to_dict(flat=True)), code=301)
+
+
+@app.route("/sectors")
+@login_required
+def sectors():
     client = get_bigquery_client()
     user_accounts = _user_account_list()
     acct_filter = _account_sql_and(user_accounts)
@@ -3789,16 +3804,16 @@ def industries():
 
     try:
         df = client.query(
-            INDUSTRIES_QUERY.format(account_filter=acct_filter)
+            SECTORS_QUERY.format(account_filter=acct_filter)
         ).to_dataframe()
     except Exception as exc:
         return render_template(
-            "industries.html",
+            "sectors.html",
             error=str(exc),
             sectors=[],
             sector_rows=[],
-            industry_rows=[],
-            industries_by_sector={},
+            subsector_rows=[],
+            subsectors_by_sector={},
             unknown_count=0,
             kpis={},
             accounts=[],
@@ -3819,7 +3834,7 @@ def industries():
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0)
 
-    for col in ("sector", "industry"):
+    for col in ("sector", "subsector"):
         if col in df.columns:
             df[col] = df[col].fillna("Unknown").astype(str).str.strip().replace("", "Unknown")
 
@@ -3827,16 +3842,16 @@ def industries():
 
     if df.empty:
         return render_template(
-            "industries.html",
+            "sectors.html",
             error=None,
             sectors=[],
             sector_rows=[],
-            industry_rows=[],
-            industries_by_sector={},
+            subsector_rows=[],
+            subsectors_by_sector={},
             unknown_count=0,
             kpis={
                 "total_pnl": 0.0, "realized_pnl": 0.0, "unrealized_pnl": 0.0,
-                "num_industries": 0, "num_symbols": 0, "num_trades": 0,
+                "num_subsectors": 0, "num_symbols": 0, "num_trades": 0,
                 "win_rate": 0.0,
             },
             accounts=accounts_for_filter,
@@ -3850,16 +3865,16 @@ def industries():
         "total_pnl": float(df["total_pnl"].sum()),
         "realized_pnl": float(df["realized_pnl"].sum()),
         "unrealized_pnl": float(df["unrealized_pnl"].sum()),
-        "num_industries": int(df["industry"].nunique()),
+        "num_subsectors": int(df["subsector"].nunique()),
         "num_symbols": int(df.groupby(["account", "symbol"]).ngroups),
         "num_trades": int(df["num_individual_trades"].sum()),
         "win_rate": (overall_winners / overall_closed) if overall_closed else 0.0,
     }
 
-    # Per-industry rollup: collapse strategy granularity, aggregate over the
-    # user's accounts. One row per (sector, industry).
-    industry_agg = (
-        df.groupby(["sector", "industry"], dropna=False)
+    # Per-subsector rollup: collapse strategy granularity, aggregate over the
+    # user's accounts. One row per (sector, subsector).
+    subsector_agg = (
+        df.groupby(["sector", "subsector"], dropna=False)
         .agg(
             total_pnl=("total_pnl", "sum"),
             realized_pnl=("realized_pnl", "sum"),
@@ -3874,39 +3889,39 @@ def industries():
         )
         .reset_index()
     )
-    closed = industry_agg["num_winners"] + industry_agg["num_losers"]
-    industry_agg["win_rate"] = industry_agg["num_winners"] / closed.replace(0, pd.NA)
-    industry_agg["win_rate"] = industry_agg["win_rate"].fillna(0)
+    closed = subsector_agg["num_winners"] + subsector_agg["num_losers"]
+    subsector_agg["win_rate"] = subsector_agg["num_winners"] / closed.replace(0, pd.NA)
+    subsector_agg["win_rate"] = subsector_agg["win_rate"].fillna(0)
 
-    # Top symbol per (sector, industry) by total_return — useful "what's
-    # actually carrying this industry?" tooltip on the card.
-    sym_in_ind = (
-        df.groupby(["sector", "industry", "symbol"], dropna=False)["total_return"]
+    # Top symbol per (sector, subsector) by total_return — useful "what's
+    # actually carrying this subsector?" tooltip on the card.
+    sym_in_sub = (
+        df.groupby(["sector", "subsector", "symbol"], dropna=False)["total_return"]
         .sum()
         .reset_index()
     )
-    if not sym_in_ind.empty:
-        sym_in_ind = sym_in_ind.sort_values(
-            ["sector", "industry", "total_return"], ascending=[True, True, False]
+    if not sym_in_sub.empty:
+        sym_in_sub = sym_in_sub.sort_values(
+            ["sector", "subsector", "total_return"], ascending=[True, True, False]
         )
         top_symbol_map = (
-            sym_in_ind.groupby(["sector", "industry"])
+            sym_in_sub.groupby(["sector", "subsector"])
             .first()
-            .reset_index()[["sector", "industry", "symbol", "total_return"]]
+            .reset_index()[["sector", "subsector", "symbol", "total_return"]]
             .rename(columns={"symbol": "top_symbol", "total_return": "top_symbol_return"})
         )
-        industry_agg = industry_agg.merge(
-            top_symbol_map, on=["sector", "industry"], how="left"
+        subsector_agg = subsector_agg.merge(
+            top_symbol_map, on=["sector", "subsector"], how="left"
         )
     else:
-        industry_agg["top_symbol"] = ""
-        industry_agg["top_symbol_return"] = 0.0
+        subsector_agg["top_symbol"] = ""
+        subsector_agg["top_symbol_return"] = 0.0
 
-    industry_agg = industry_agg.sort_values("total_return", ascending=False)
-    industry_rows = industry_agg.to_dict(orient="records")
+    subsector_agg = subsector_agg.sort_values("total_return", ascending=False)
+    subsector_rows = subsector_agg.to_dict(orient="records")
 
     # Sector rollup — this is now the primary view on the page, so it carries
-    # the same shape as industry_rows: realized / unrealized / premium /
+    # the same shape as subsector_rows: realized / unrealized / premium /
     # dividends / total_return so the sector cards have everything at a glance.
     sector_agg = (
         df.groupby(["sector"], dropna=False)
@@ -3917,7 +3932,7 @@ def industries():
             premium_received=("total_premium_received", "sum"),
             dividend_income=("total_dividend_income", "sum"),
             total_return=("total_return", "sum"),
-            num_industries=("industry", "nunique"),
+            num_subsectors=("subsector", "nunique"),
             num_symbols=("symbol", "nunique"),
             num_trades=("num_individual_trades", "sum"),
             num_winners=("num_winners", "sum"),
@@ -3957,31 +3972,31 @@ def industries():
 
     sector_agg = sector_agg.sort_values("total_pnl", ascending=False)
     sector_rows = sector_agg.to_dict(orient="records")
-    sectors = sector_agg["sector"].tolist()
+    sectors_list = sector_agg["sector"].tolist()
 
-    # Group industries under their sector for the collapsible drill-down on
-    # the page. Order each sector's industries by total_return desc.
-    industries_by_sector: dict[str, list[dict]] = {}
-    for r in industry_rows:
-        industries_by_sector.setdefault(r["sector"], []).append(r)
-    for sec in industries_by_sector:
-        industries_by_sector[sec].sort(
+    # Group subsectors under their sector for the collapsible drill-down on
+    # the page. Order each sector's subsectors by total_return desc.
+    subsectors_by_sector: dict[str, list[dict]] = {}
+    for r in subsector_rows:
+        subsectors_by_sector.setdefault(r["sector"], []).append(r)
+    for sec in subsectors_by_sector:
+        subsectors_by_sector[sec].sort(
             key=lambda x: x.get("total_return", 0), reverse=True
         )
 
     unknown_count = int(
-        ((df["sector"] == "Unknown") | (df["industry"] == "Unknown"))
+        ((df["sector"] == "Unknown") | (df["subsector"] == "Unknown"))
         .pipe(lambda s: s.groupby([df["account"], df["symbol"]]).any())
         .sum()
     )
 
     return render_template(
-        "industries.html",
+        "sectors.html",
         error=None,
-        sectors=sectors,
+        sectors=sectors_list,
         sector_rows=sector_rows,
-        industry_rows=industry_rows,
-        industries_by_sector=industries_by_sector,
+        subsector_rows=subsector_rows,
+        subsectors_by_sector=subsectors_by_sector,
         unknown_count=unknown_count,
         kpis=kpis,
         accounts=accounts_for_filter,
@@ -3993,9 +4008,9 @@ def industries():
 # Strategy fit  (/strategy-fit)
 # ======================================================================
 #
-# Cross-tab of strategy x sector (or strategy x industry when drilled into
+# Cross-tab of strategy x sector (or strategy x subsector when drilled into
 # a single sector) so users can see "what strategies work best in what
-# kinds of companies?". Same tenancy guarantees as /industries — query is
+# kinds of companies?". Same tenancy guarantees as /sectors — query is
 # scoped by _account_sql_and AND the DataFrame is _filter_df_by_accounts'd
 # before any aggregation.
 # ----------------------------------------------------------------------
@@ -4014,7 +4029,7 @@ STRATEGY_FIT_QUERY = """
         num_winners,
         num_losers,
         sector,
-        industry
+        subsector
     FROM `ccwj-dbt.analytics.positions_summary`
     WHERE 1=1
     {account_filter}
@@ -4057,7 +4072,7 @@ DIM_FIXED_COL_ORDER = {
 # Map dim -> (column field in DataFrame, human label for headers/lede).
 DIM_META = {
     "sector":     ("sector",            "Sector",     "sectors"),
-    "industry":   ("industry",          "Industry",   "industries"),
+    "subsector":  ("subsector",         "Subsector",  "subsectors"),
     "dte":        ("dte_bucket",        "DTE",        "DTE buckets"),
     "moneyness":  ("moneyness_at_open", "Moneyness",  "moneyness buckets"),
 }
@@ -4347,9 +4362,9 @@ def _strategy_fit_render_payload(
     col_field, dim_label, dim_label_plural = DIM_META.get(
         dim, DIM_META["sector"]
     )
-    # AI insight payload was built for sector/industry — null it out on
+    # AI insight payload was built for sector/subsector — null it out on
     # other dims so the template's "AI Insight" card hides cleanly.
-    if dim not in ("sector", "industry"):
+    if dim not in ("sector", "subsector"):
         insight_ctx = {
             **insight_ctx,
             "ai_summary": None,
@@ -4376,7 +4391,7 @@ def _strategy_fit_render_payload(
         col_field=col_field,
         dim=dim,
         # mode is preserved for backward-compat in the template (it used
-        # to be sector|industry only); now mirrors dim 1:1.
+        # to be sector|subsector only); now mirrors dim 1:1.
         mode=dim,
         dim_label=dim_label,
         dim_label_plural=dim_label_plural,
@@ -4395,15 +4410,18 @@ def strategy_fit():
     acct_filter = _account_sql_and(user_accounts)
 
     selected_account = request.args.get("account", "")
-    drill_sector = request.args.get("sector", "")  # implies industry mode
+    drill_sector = request.args.get("sector", "")  # implies subsector mode
 
     # Resolve the column dimension. Drilling into a sector wins (for
-    # backward URL compat) and forces industry mode. Otherwise read ?dim=
-    # and validate against the supported set.
+    # backward URL compat) and forces subsector mode. Otherwise read ?dim=
+    # and validate against the supported set. 'industry' is the pre-rename
+    # alias for 'subsector' — accept it so old bookmarks keep working.
     requested_dim = (request.args.get("dim", "") or "").strip().lower()
+    if requested_dim == "industry":
+        requested_dim = "subsector"
     if drill_sector:
-        dim = "industry"
-    elif requested_dim in ("dte", "moneyness", "industry", "sector"):
+        dim = "subsector"
+    elif requested_dim in ("dte", "moneyness", "subsector", "sector"):
         dim = requested_dim
     else:
         dim = "sector"
@@ -4411,7 +4429,7 @@ def strategy_fit():
     insight_ctx = _strategy_fit_insight_context(selected_account)
 
     # Fan out the queries we need. positions_summary is always needed —
-    # for sector/industry it's the data source, and for dte/moneyness
+    # for sector/subsector it's the data source, and for dte/moneyness
     # it's where we discover the equity-only strategy set so the matrix
     # can show "N/A — equity" rows.
     queries = {"summary": STRATEGY_FIT_QUERY.format(account_filter=acct_filter)}
@@ -4446,7 +4464,7 @@ def strategy_fit():
                 "num_individual_trades", "num_winners", "num_losers"):
         if col in summary_df.columns:
             summary_df.loc[:, col] = pd.to_numeric(summary_df[col], errors="coerce").fillna(0)
-    for col in ("sector", "industry", "strategy"):
+    for col in ("sector", "subsector", "strategy"):
         if col in summary_df.columns:
             summary_df.loc[:, col] = (
                 summary_df[col].fillna("Unknown").astype(str).str.strip().replace("", "Unknown")
@@ -4508,10 +4526,10 @@ def strategy_fit():
         )
     else:
         df = summary_df
-        if dim == "industry":
-            # Drill: filter to one sector, columns become industries.
+        if dim == "subsector":
+            # Drill: filter to one sector, columns become subsectors.
             df = df[df["sector"] == drill_sector]
-            col_field = "industry"
+            col_field = "subsector"
             col_order_override = None
         else:
             col_field = "sector"

--- a/app/strategy_fit_insights.py
+++ b/app/strategy_fit_insights.py
@@ -49,7 +49,7 @@ STRATEGY_FIT_QUERY = """
         num_winners,
         num_losers,
         sector,
-        industry
+        subsector
     FROM `ccwj-dbt.analytics.positions_summary`
     WHERE 1=1
     {account_filter}
@@ -108,7 +108,7 @@ def _build_strategy_fit_brief(client, user_accounts):
               "num_individual_trades", "num_winners", "num_losers"):
         if c in df.columns:
             df[c] = pd.to_numeric(df[c], errors="coerce").fillna(0)
-    for c in ("sector", "industry", "symbol", "strategy"):
+    for c in ("sector", "subsector", "symbol", "strategy"):
         if c in df.columns:
             df[c] = df[c].fillna("Unknown").astype(str)
 
@@ -212,7 +212,8 @@ def _build_strategy_fit_brief(client, user_accounts):
 
     # Sector-level top symbols (across all strategies). Used so the LLM
     # can name actual tickers when it mentions a sector — most users
-    # don't memorize industry classifications, but they know their symbols.
+    # don't memorize sector / subsector classifications, but they know
+    # their symbols.
     sec_sym_agg = (
         df.groupby(["sector", "symbol"], dropna=False)
         .agg(
@@ -467,8 +468,8 @@ Voice and structure:
   ("These are still small samples — keep watching.").
 
 CRITICAL — symbol attribution:
-- The trader does NOT memorize industry classifications, but they DO
-  remember every ticker they trade. Whenever you name a sector
+- The trader does NOT memorize sector / subsector classifications, but
+  they DO remember every ticker they trade. Whenever you name a sector
   (e.g. "Industrials", "Technology", "Healthcare"), you MUST cite the
   specific ticker symbols from the brief in parentheses immediately
   after the sector name.

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -232,7 +232,7 @@
             {% set ep = request.endpoint or '' %}
             {% set selected_account = request.args.get('account', '') %}
             {% set in_portfolio = ep in ('positions', 'symbols_detail', 'accounts') %}
-            {% set in_breakdowns = ep in ('strategies', 'industries', 'strategy_fit') %}
+            {% set in_breakdowns = ep in ('strategies', 'sectors', 'strategy_fit') %}
             <ul class="navbar-nav me-auto">
                 <li class="nav-item">
                     <a class="nav-link {% if ep == 'weekly_review' %}active{% endif %}"
@@ -265,8 +265,8 @@
                                href="{{ url_for('strategies', account=selected_account) if selected_account else url_for('strategies') }}">Strategies</a>
                         </li>
                         <li>
-                            <a class="dropdown-item {% if ep == 'industries' %}active{% endif %}"
-                               href="{{ url_for('industries', account=selected_account) if selected_account else url_for('industries') }}">Industries</a>
+                            <a class="dropdown-item {% if ep == 'sectors' %}active{% endif %}"
+                               href="{{ url_for('sectors', account=selected_account) if selected_account else url_for('sectors') }}">Sectors</a>
                         </li>
                         <li><hr class="dropdown-divider"></li>
                         <li>

--- a/app/templates/faq.html
+++ b/app/templates/faq.html
@@ -160,11 +160,11 @@
             <div class="faq-item">
                 <h3 class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                     data-bs-target="#faq-sectors" aria-expanded="false" aria-controls="faq-sectors">
-                    How do you tag sectors and industries?
+                    How do you tag sectors and subsectors?
                 </h3>
                 <div id="faq-sectors" class="accordion-collapse collapse" data-bs-parent="#faqAccordion">
                     <div class="faq-answer">
-                        Every ticker you trade is automatically tagged with its sector and industry using public market data &mdash; no manual entry. Your performance rolls up by sector on the <strong>Industries</strong> page so you can see at a glance where your edge actually lives.
+                        Every ticker you trade is automatically tagged with its sector and subsector using public market data &mdash; no manual entry. Your performance rolls up by sector on the <strong>Sectors</strong> page so you can see at a glance where your edge actually lives.
                     </div>
                 </div>
             </div>

--- a/app/templates/landing.html
+++ b/app/templates/landing.html
@@ -232,14 +232,14 @@
         </a>
     </div>
     <div class="col-sm-6 col-lg-4">
-        <a href="{{ url_for('industries') if current_user.is_authenticated else url_for('signup') }}" class="card feature-card">
+        <a href="{{ url_for('sectors') if current_user.is_authenticated else url_for('signup') }}" class="card feature-card">
             <div class="feature-icon" style="background:rgba(13,148,136,.12); color:#0d9488">
                 <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" fill="currentColor" viewBox="0 0 16 16">
                     <path d="M14.763.075A.5.5 0 0 1 15 .5v15a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5V11h-1V8a.5.5 0 0 0-.5-.5H8.5v-1H7.515c-.146 0-.272-.044-.396-.118l-1.18-.708a.5.5 0 0 1-.063-.84l1.71-1.41a.5.5 0 0 1 .064-.041L11 1.232V.5a.5.5 0 0 1 .763-.425zM4.5 15a.5.5 0 0 1-.5.5h-3a.5.5 0 0 1-.5-.5V14h4z"/>
                 </svg>
             </div>
-            <h6>Sector &amp; industry insights</h6>
-            <p>See where you actually have edge. Each ticker tagged by sector and industry, so you know which corners of the market are working for you.</p>
+            <h6>Sector &amp; subsector insights</h6>
+            <p>See where you actually have edge. Each ticker tagged by sector and subsector, so you know which corners of the market are working for you.</p>
         </a>
     </div>
     <div class="col-sm-6 col-lg-4">

--- a/app/templates/position_detail.html
+++ b/app/templates/position_detail.html
@@ -78,12 +78,12 @@
             {% if symbol_company %}
             <div class="text-white-50" style="font-size: .9rem; margin-top: -.15rem;">{{ symbol_company }}</div>
             {% endif %}
-            {% if symbol_industry and symbol_industry != 'Unknown' %}
+            {% if symbol_subsector and symbol_subsector != 'Unknown' %}
             <div class="mt-1">
-                <a href="{{ url_for('industries') }}#{{ (symbol_sector or 'unknown')|replace(' ', '-')|lower }}"
+                <a href="{{ url_for('sectors') }}#{{ (symbol_sector or 'unknown')|replace(' ', '-')|lower }}"
                    class="text-decoration-none"
                    style="display:inline-flex; align-items:center; gap:.4rem; background: rgba(255,255,255,.12); color: #fff; padding: .15rem .65rem; border-radius: 999px; font-size: .72rem; font-weight: 600; letter-spacing: .02em;">
-                    {% if symbol_sector and symbol_sector != 'Unknown' %}{{ symbol_sector }}<span style="opacity:.55;"> / </span>{% endif %}{{ symbol_industry }}
+                    {% if symbol_sector and symbol_sector != 'Unknown' %}{{ symbol_sector }}<span style="opacity:.55;"> / </span>{% endif %}{{ symbol_subsector }}
                 </a>
             </div>
             {% endif %}

--- a/app/templates/positions.html
+++ b/app/templates/positions.html
@@ -242,14 +242,14 @@
             {% endfor %}
         </select>
     </div>
-    {% if industries %}
+    {% if subsectors %}
     <div>
-        <label class="lblh">Industry</label>
-        <select name="industry" class="form-select form-select-sm"
+        <label class="lblh">Subsector</label>
+        <select name="subsector" class="form-select form-select-sm"
                 onchange="this.form.submit()">
-            <option value="">All Industries</option>
-            {% for ind in industries %}
-            <option value="{{ ind }}" {{ 'selected' if ind == selected_industry }}>{{ ind }}</option>
+            <option value="">All Subsectors</option>
+            {% for sub in subsectors %}
+            <option value="{{ sub }}" {{ 'selected' if sub == selected_subsector }}>{{ sub }}</option>
             {% endfor %}
         </select>
     </div>
@@ -264,11 +264,11 @@
         <label class="lblh">Status</label>
         <div class="seg-toggle">
             <a class="{{ 'active' if _all_statuses }}"
-               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, industry=selected_industry, start_date=selected_start_date, end_date=selected_end_date) }}">All</a>
+               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, subsector=selected_subsector, start_date=selected_start_date, end_date=selected_end_date) }}">All</a>
             <a class="{{ 'active' if (not _all_statuses and selected_statuses == ['Open']) }}"
-               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, industry=selected_industry, status=['Open'], start_date=selected_start_date, end_date=selected_end_date) }}">Open</a>
+               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, subsector=selected_subsector, status=['Open'], start_date=selected_start_date, end_date=selected_end_date) }}">Open</a>
             <a class="{{ 'active' if (not _all_statuses and selected_statuses == ['Closed']) }}"
-               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, industry=selected_industry, status=['Closed'], start_date=selected_start_date, end_date=selected_end_date) }}">Closed</a>
+               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, subsector=selected_subsector, status=['Closed'], start_date=selected_start_date, end_date=selected_end_date) }}">Closed</a>
         </div>
         {# Mirror the chosen status into the form so a Symbol/Strategy
            change preserves it. Multi-status (rare path) still works
@@ -283,11 +283,11 @@
         <label class="lblh">Dates</label>
         <div class="seg-toggle">
             <a class="{{ 'active' if _is_alltime }}"
-               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, industry=selected_industry, status=selected_statuses) }}">All time</a>
+               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, subsector=selected_subsector, status=selected_statuses) }}">All time</a>
             <a class="{{ 'active' if _is_30d }}"
-               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, industry=selected_industry, status=selected_statuses, start_date=(today - timedelta(days=30)).strftime('%Y-%m-%d'), end_date=today.strftime('%Y-%m-%d')) }}">Last 30d</a>
+               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, subsector=selected_subsector, status=selected_statuses, start_date=(today - timedelta(days=30)).strftime('%Y-%m-%d'), end_date=today.strftime('%Y-%m-%d')) }}">Last 30d</a>
             <a class="{{ 'active' if _is_ytd }}"
-               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, industry=selected_industry, status=selected_statuses, start_date=today.replace(month=1, day=1).strftime('%Y-%m-%d'), end_date=today.strftime('%Y-%m-%d')) }}">YTD</a>
+               href="{{ url_for('positions', account=selected_account, strategy=selected_strategy, symbol=selected_symbol, subsector=selected_subsector, status=selected_statuses, start_date=today.replace(month=1, day=1).strftime('%Y-%m-%d'), end_date=today.strftime('%Y-%m-%d')) }}">YTD</a>
         </div>
         {# No hidden date inputs needed — the visible date inputs below
            are part of this form and carry the current values, so when
@@ -304,7 +304,7 @@
                    value="{{ selected_end_date }}" onchange="this.form.submit()" style="min-width: 8.5rem;">
         </div>
     </div>
-    {% if selected_account or selected_symbol or selected_strategy or selected_industry or selected_statuses or selected_start_date or selected_end_date %}
+    {% if selected_account or selected_symbol or selected_strategy or selected_subsector or selected_statuses or selected_start_date or selected_end_date %}
     <a class="filter-reset" href="{{ url_for('positions') }}">Reset</a>
     {% endif %}
 </form>
@@ -411,7 +411,7 @@
                     <tr>
                         <th class="sortable" data-sort="str">Account</th>
                         <th class="sortable" data-sort="str">Symbol</th>
-                        <th class="sortable" data-sort="str">Industry</th>
+                        <th class="sortable" data-sort="str">Subsector</th>
                         <th>Strategies</th>
                         <th class="sortable" data-sort="num">Total P&amp;L</th>
                         <th class="sortable" data-sort="num">Realized</th>
@@ -434,10 +434,10 @@
                             </a>
                         </td>
                         <td class="small text-muted" style="max-width: 180px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
-                            title="{{ row.sector or '' }}{% if row.sector and row.industry %} / {% endif %}{{ row.industry or '' }}">
-                            {% if row.industry and row.industry != 'Unknown' %}
-                            <a href="{{ url_for('positions', industry=row.industry, account=selected_account) }}"
-                               class="text-decoration-none text-muted">{{ row.industry }}</a>
+                            title="{{ row.sector or '' }}{% if row.sector and row.subsector %} / {% endif %}{{ row.subsector or '' }}">
+                            {% if row.subsector and row.subsector != 'Unknown' %}
+                            <a href="{{ url_for('positions', subsector=row.subsector, account=selected_account) }}"
+                               class="text-decoration-none text-muted">{{ row.subsector }}</a>
                             {% else %}
                             <span class="text-muted">—</span>
                             {% endif %}

--- a/app/templates/pricing.html
+++ b/app/templates/pricing.html
@@ -75,7 +75,7 @@
                         <li>Strategy auto-detection</li>
                         <li>Weekly review with narrative</li>
                         <li>Position detail &amp; drill-down</li>
-                        <li>Sector &amp; industry breakdown</li>
+                        <li>Sector &amp; subsector breakdown</li>
                         <li>Strategy fit matrix</li>
                         <li>AI Coach (insights &amp; chat)</li>
                         <li>Schwab Connect or CSV upload</li>

--- a/app/templates/sectors.html
+++ b/app/templates/sectors.html
@@ -2,6 +2,9 @@
 
 {% block head %}
 <style>
+    /* CSS class names are kept as `.ind-*` (legacy from when this page
+       was called Industries) to keep the diff focused. They now style
+       sector / subsector content; class meaning is internal-only. */
     .ind-hero {
         background: linear-gradient(135deg, #1e1b4b 0%, #4c1d95 100%);
         color: #fff;
@@ -78,7 +81,7 @@
     }
     .sec-card .btn-positions:hover { background: #e0e7ff; }
 
-    /* Industry breakdown — only visible when sector is expanded */
+    /* Subsector breakdown — only visible when sector is expanded */
     .sec-card .ind-list { display: none; flex-direction: column; gap: .4rem; padding-top: .25rem; }
     .sec-card.expanded .ind-list { display: flex; }
     .ind-row {
@@ -118,11 +121,11 @@
 
 <div class="ind-hero">
     <div>
-        <h1>Industries</h1>
-        <p class="lede">How your trading breaks down by sector. Click a sector to see the specific industries you've traded inside it.</p>
+        <h1>Sectors</h1>
+        <p class="lede">How your trading breaks down by sector. Click a sector to see the specific subsectors you've traded inside it.</p>
     </div>
 
-    {% if kpis and kpis.num_industries > 0 %}
+    {% if kpis and kpis.num_subsectors > 0 %}
     <div class="ind-kpis">
         <div class="ind-kpi">
             <div class="lbl">Total P&amp;L</div>
@@ -135,8 +138,8 @@
             <div class="val">{{ sectors|length }}</div>
         </div>
         <div class="ind-kpi">
-            <div class="lbl">Industries</div>
-            <div class="val">{{ kpis.num_industries }}</div>
+            <div class="lbl">Subsectors</div>
+            <div class="val">{{ kpis.num_subsectors }}</div>
         </div>
         <div class="ind-kpi">
             <div class="lbl">Symbols</div>
@@ -158,7 +161,7 @@
 {% elif not sector_rows %}
 <div class="ind-empty">
     <strong>No sector breakdown yet.</strong>
-    <p class="mb-0 mt-2">Once your trades come in and we tag the symbols, you'll see your performance broken out by sector and industry.</p>
+    <p class="mb-0 mt-2">Once your trades come in and we tag the symbols, you'll see your performance broken out by sector and subsector.</p>
     <div class="mt-3 d-flex flex-wrap gap-2 justify-content-center">
         <a href="{{ url_for('profile') }}#schwab-sync" class="btn btn-primary btn-sm">Connect Schwab</a>
         <a href="{{ url_for('upload') }}" class="btn btn-outline-primary btn-sm">Upload trade history</a>
@@ -179,7 +182,7 @@
         </select>
     </div>
     {% if selected_account %}
-    <a class="filter-reset" href="{{ url_for('industries') }}">Reset</a>
+    <a class="filter-reset" href="{{ url_for('sectors') }}">Reset</a>
     {% endif %}
 </form>
 {% endif %}
@@ -187,14 +190,14 @@
 <div class="sec-grid">
     {% for s in sector_rows %}
     {% set sec_id = s.sector|replace(' ', '-')|lower %}
-    {% set inds = industries_by_sector.get(s.sector, []) %}
+    {% set subs = subsectors_by_sector.get(s.sector, []) %}
     <article class="sec-card" id="{{ sec_id }}" data-sector="{{ s.sector }}">
         <div class="head">
             <div>
                 <div class="name">{{ s.sector }}</div>
                 <div class="meta">
                     {{ s.num_symbols }} symbol{% if s.num_symbols != 1 %}s{% endif %}
-                    &middot; {{ s.num_industries }} industr{% if s.num_industries == 1 %}y{% else %}ies{% endif %}
+                    &middot; {{ s.num_subsectors }} subsector{% if s.num_subsectors != 1 %}s{% endif %}
                     &middot; {{ s.num_trades | int }} trade{% if s.num_trades != 1 %}s{% endif %}
                 </div>
             </div>
@@ -263,9 +266,9 @@
         {% endif %}
 
         <div class="actions">
-            {% if inds and inds|length > 0 %}
+            {% if subs and subs|length > 0 %}
             <button type="button" class="btn-toggle" data-target="{{ sec_id }}-inds">
-                <span class="lbl-show">Show {{ inds|length }} industr{% if inds|length == 1 %}y{% else %}ies{% endif %}</span>
+                <span class="lbl-show">Show {{ subs|length }} subsector{% if subs|length != 1 %}s{% endif %}</span>
                 <span class="chev">▾</span>
             </button>
             {% endif %}
@@ -274,12 +277,12 @@
             </a>
         </div>
 
-        {% if inds and inds|length > 0 %}
+        {% if subs and subs|length > 0 %}
         <div class="ind-list" id="{{ sec_id }}-inds">
-            {% for r in inds %}
+            {% for r in subs %}
             <div class="ind-row">
-                <div class="ind-name" title="{{ r.industry }}">
-                    <a href="{{ url_for('positions', industry=r.industry, account=selected_account) }}">{{ r.industry }}</a>
+                <div class="ind-name" title="{{ r.subsector }}">
+                    <a href="{{ url_for('positions', subsector=r.subsector, account=selected_account) }}">{{ r.subsector }}</a>
                     <div class="ind-meta">
                         {{ r.num_symbols }} symbol{% if r.num_symbols != 1 %}s{% endif %}
                         &middot; {{ r.num_trades | int }} trade{% if r.num_trades != 1 %}s{% endif %}
@@ -291,7 +294,7 @@
                 <div class="ind-pnl {% if r.total_pnl >= 0 %}pos{% else %}neg{% endif %}">
                     ${{ "{:,.0f}".format(r.total_pnl) }}
                 </div>
-                <a class="ind-link" href="{{ url_for('positions', industry=r.industry, account=selected_account) }}">View</a>
+                <a class="ind-link" href="{{ url_for('positions', subsector=r.subsector, account=selected_account) }}">View</a>
             </div>
             {% endfor %}
         </div>

--- a/app/templates/strategy_fit.html
+++ b/app/templates/strategy_fit.html
@@ -445,12 +445,12 @@
 {% else %}
 
 {# ── AI-narrated insights ───────────────────────────────────────────
-   AI insight is currently keyed to sector/industry data only. On
+   AI insight is currently keyed to sector/subsector data only. On
    DTE / Moneyness / Market Cap dims we hide the card with a small
    note rather than offering a Generate button that would mismatch
    the matrix the user is looking at. (Per-dim insights = v2.)
 #}
-{% if ai_enabled and dim in ('sector', 'industry') %}
+{% if ai_enabled and dim in ('sector', 'subsector') %}
 {% if ai_summary %}
 <div class="ai-card" id="aiCard">
     <div class="ai-head">
@@ -535,16 +535,16 @@
 
 {# ── Controls: dimension switcher + metric toggle + visibility ── #}
 <div class="fit-controls">
-    {# "Slice by" dimension switcher. Industry isn't a top-level option —
+    {# "Slice by" dimension switcher. Subsector isn't a top-level option —
        it's reached by drilling a Sector cell — so we surface it here only
-       when the user is currently in industry-drill mode. #}
+       when the user is currently in subsector-drill mode. #}
     <div>
         <label class="lblh">Slice by</label>
         <div class="metric-toggle" id="dimSwitcher">
             <a href="{{ url_for('strategy_fit', dim='sector', account=selected_account) }}"
                class="{% if dim == 'sector' %}active{% endif %}">Sector</a>
-            {% if dim == 'industry' %}
-            <a href="#" class="active" aria-current="page">Industry</a>
+            {% if dim == 'subsector' %}
+            <a href="#" class="active" aria-current="page">Subsector</a>
             {% endif %}
             <a href="{{ url_for('strategy_fit', dim='dte', account=selected_account) }}"
                class="{% if dim == 'dte' %}active{% endif %}">DTE</a>
@@ -593,7 +593,7 @@
     </form>
     {% endif %}
 
-    {% if dim == 'industry' %}
+    {% if dim == 'subsector' %}
     <a class="btn btn-sm btn-outline-secondary"
        href="{{ url_for('strategy_fit', dim='sector', account=selected_account) }}">
         ← Back to all sectors
@@ -627,7 +627,7 @@
                 <th class="{% if col == 'Unknown' %}col-unknown{% endif %}">
                     {% if dim == 'sector' %}
                     <a href="{{ url_for('strategy_fit', sector=col, account=selected_account) }}"
-                       title="Drill into {{ col }} industries">{{ col }}</a>
+                       title="Drill into {{ col }} subsectors">{{ col }}</a>
                     {% else %}
                     {{ col }}
                     {% endif %}
@@ -645,7 +645,7 @@
             </tr>
         </thead>
         <tbody>
-            {% set positions_dim = dim in ('sector', 'industry') %}
+            {% set positions_dim = dim in ('sector', 'subsector') %}
             {% set equity_set = equity_strategies or [] %}
             {% for strat in row_labels %}
             {% set rt = row_totals.get(strat) %}
@@ -668,7 +668,7 @@
                     {% set c = cells.get(strat, {}).get(col) %}
                     {% if c and c.num_trades and c.num_trades > 0 %}
                         {% if positions_dim %}
-                            {% set drill_url = url_for('positions', strategy=strat, sector=(col if dim == 'sector' else drill_sector), industry=('' if dim == 'sector' else col), account=selected_account) %}
+                            {% set drill_url = url_for('positions', strategy=strat, sector=(col if dim == 'sector' else drill_sector), subsector=('' if dim == 'sector' else col), account=selected_account) %}
                         {% else %}
                             {% set drill_url = '' %}
                         {% endif %}
@@ -1008,7 +1008,7 @@ const BASELINE_WIN_RATE   = {{ baseline_win_rate|float }};
               ' (of ' + (parseInt(td.dataset.numSymbols, 10) || symbols.length) + ')'
             : 'Symbols';
 
-        // The Positions page can filter by strategy + sector/industry, but
+        // The Positions page can filter by strategy + sector/subsector, but
         // not by DTE / Moneyness / Market Cap. Hide the CTA on those dims
         // rather than render a broken link — the symbol list above is the
         // actionable affordance there.

--- a/dbt/models/intermediate/int_enriched_current.sql
+++ b/dbt/models/intermediate/int_enriched_current.sql
@@ -93,11 +93,10 @@ select
     cp.snapshot_date,
     lp.price_date,
 
-    -- Sector / industry from yfinance (Unknown when missing)
-    coalesce(sm.sector, 'Unknown')          as sector,
-    coalesce(sm.industry, 'Unknown')        as industry,
-    coalesce(sm.industry_group, 'Unknown')  as industry_group,
-    sm.long_name                            as company_name
+    -- Sector / subsector from yfinance (Unknown when missing)
+    coalesce(sm.sector, 'Unknown')      as sector,
+    coalesce(sm.subsector, 'Unknown')   as subsector,
+    sm.long_name                         as company_name
 
 from current_positions cp
 left join latest_prices lp

--- a/dbt/models/marts/positions_summary.sql
+++ b/dbt/models/marts/positions_summary.sql
@@ -141,14 +141,13 @@ final as (
             + case when wdr.dividend_rank = 1 then coalesce(d.total_dividend_income, 0) else 0 end
         , 2) as total_return,
 
-        -- Sector / industry context (yfinance, refreshed daily). Coalesce so
+        -- Sector / subsector context (yfinance, refreshed daily). Coalesce so
         -- a missing-from-yfinance ticker still has 'Unknown' instead of NULL,
         -- which lets the app filter/group without special-casing nulls.
-        coalesce(sm.sector, 'Unknown')         as sector,
-        coalesce(sm.industry, 'Unknown')       as industry,
-        coalesce(sm.industry_group, 'Unknown') as industry_group,
-        sm.long_name                            as company_name,
-        sm.market_cap                           as market_cap
+        coalesce(sm.sector, 'Unknown')      as sector,
+        coalesce(sm.subsector, 'Unknown')   as subsector,
+        sm.long_name                         as company_name,
+        sm.market_cap                        as market_cap
 
     from with_dividend_rank wdr
     left join dividends d

--- a/dbt/models/staging/sources.yml
+++ b/dbt/models/staging/sources.yml
@@ -18,14 +18,15 @@ sources:
           - name: dividend
       - name: symbol_metadata
         description: >
-          Sector / industry / market cap / company name per symbol, fetched
+          Sector / subsector / market cap / company name per symbol, fetched
           via yfinance by scripts/refresh_symbol_metadata.py (runs in
           GitHub Actions). Symbol-only — no account column, safe to share.
+          'subsector' is the more specific bucket nested under 'sector'
+          (e.g. sector=Technology / subsector=Software-Application).
         columns:
           - name: symbol
           - name: sector
-          - name: industry
-          - name: industry_group
+          - name: subsector
           - name: country
           - name: market_cap
           - name: long_name

--- a/dbt/models/staging/stg_symbol_metadata.sql
+++ b/dbt/models/staging/stg_symbol_metadata.sql
@@ -4,11 +4,18 @@
     )
 }}
 
--- Sector / industry per symbol, sourced from yfinance via
+-- Sector / subsector per symbol, sourced from yfinance via
 -- scripts/refresh_symbol_metadata.py. Trim/upper the symbol so joins
 -- against stg_history (which already upper/trims) line up cleanly, and
 -- coalesce nulls to 'Unknown' so downstream filters don't have to
 -- special-case nulls everywhere.
+--
+-- "Subsector" was previously called "industry" to match yfinance's API
+-- field name; we standardized on the finance-industry term "subsector"
+-- (sector → subsector hierarchy). refresh_symbol_metadata.py runs
+-- BEFORE the dbt build in CI (and locally) and overwrites the source
+-- table with WRITE_TRUNCATE, so by the time this view is rebuilt the
+-- new column name is in place.
 
 with src as (
     select * from {{ source('external', 'symbol_metadata') }}
@@ -17,10 +24,9 @@ with src as (
 cleaned as (
     select
         upper(trim(symbol))                         as symbol,
-        coalesce(nullif(trim(sector), ''),  'Unknown') as sector,
-        coalesce(nullif(trim(industry), ''),'Unknown') as industry,
-        coalesce(nullif(trim(industry_group), ''), industry, 'Unknown') as industry_group,
-        coalesce(nullif(trim(country), ''), 'Unknown') as country,
+        coalesce(nullif(trim(sector), ''),    'Unknown') as sector,
+        coalesce(nullif(trim(subsector), ''), 'Unknown') as subsector,
+        coalesce(nullif(trim(country), ''),   'Unknown') as country,
         market_cap,
         long_name,
         fetched_at

--- a/deploy.txt
+++ b/deploy.txt
@@ -14,12 +14,12 @@ New Updates
     - Built a 12-check internal audit that runs over the data and
       confirms every page agrees on every number. All 12 pass today.
 
-    Sector & industry reporting (new)
-    - New Industries page: P&L and win rate broken down by sector and
-      industry, with click-through to the underlying positions.
-    - Every position is now tagged with sector, industry, and company
+    Sector & subsector reporting (new)
+    - New Sectors page: P&L and win rate broken down by sector and
+      subsector, with click-through to the underlying positions.
+    - Every position is now tagged with sector, subsector, and company
       name, refreshed daily.
-    - Positions list has an Industry filter and an Industry column.
+    - Positions list has a Subsector filter and a Subsector column.
     - Strategy Fit insights are now organized as Strategy x Sector so
       it's easy to see which sectors a given strategy actually works in.
 

--- a/scripts/audit/reconcile.py
+++ b/scripts/audit/reconcile.py
@@ -274,9 +274,9 @@ def main():
         print("PASS — every positions_summary row has total_pnl = realized + unrealized")
 
     # ====================================================================
-    # CHECK 6: Industries page — sum across sectors == positions total
+    # CHECK 6: Sectors page — sum across sectors == positions total
     # ====================================================================
-    section("CHECK 6: Industries (sector) total P&L vs positions total return")
+    section("CHECK 6: Sectors total P&L vs positions total return")
     sql6 = f"""
         SELECT
           account,

--- a/scripts/refresh_symbol_metadata.py
+++ b/scripts/refresh_symbol_metadata.py
@@ -1,7 +1,15 @@
 """
-Refresh symbol_metadata: pull sector / industry / market cap / company name
-from yfinance for every ticker that shows up in stg_history (plus SPY/QQQ
-benchmarks), and load it into ccwj-dbt.analytics.symbol_metadata.
+Refresh symbol_metadata: pull sector / subsector / market cap / company
+name from yfinance for every ticker that shows up in stg_history (plus
+SPY/QQQ benchmarks), and load it into ccwj-dbt.analytics.symbol_metadata.
+
+We use the finance-standard hierarchy "sector → subsector". yfinance
+exposes these under the keys 'sector' and 'industry' (and a friendlier
+'industryDisp' display string), but everywhere else in this codebase
+they're called sector / subsector — including the BigQuery table this
+script writes. yfinance keys → BigQuery columns:
+  - info['sector']                       → sector
+  - info['industryDisp'] or ['industry'] → subsector
 
 Mirrors the operational pattern of current_position_stock_price.py:
   - Read distinct symbols out of BigQuery
@@ -54,18 +62,19 @@ def _fetch_one(symbol: str) -> dict | None:
         return None
 
     sector = info.get("sector")
-    industry = info.get("industry")
-    industry_disp = info.get("industryDisp") or industry
-    if not sector and not industry:
+    # Prefer yfinance's display string ('industryDisp') over the slug
+    # ('industry'); it's the same hierarchy level but the human-readable
+    # version (e.g. "Software—Application" vs "software-application").
+    subsector = info.get("industryDisp") or info.get("industry")
+    if not sector and not subsector:
         # No metadata at all — likely a delisted / OTC / synthetic symbol.
         # Still record the row so we know we tried, with Unknown placeholders.
-        print(f"  - {symbol}: no sector/industry from yfinance")
+        print(f"  - {symbol}: no sector/subsector from yfinance")
 
     return {
         "symbol": symbol,
         "sector": sector or "Unknown",
-        "industry": industry or "Unknown",
-        "industry_group": industry_disp or industry or "Unknown",
+        "subsector": subsector or "Unknown",
         "country": info.get("country") or "Unknown",
         "market_cap": int(info["marketCap"]) if info.get("marketCap") else None,
         "long_name": info.get("longName") or info.get("shortName") or symbol,
@@ -97,8 +106,7 @@ def main() -> None:
     schema = [
         bigquery.SchemaField("symbol", "STRING", mode="REQUIRED"),
         bigquery.SchemaField("sector", "STRING"),
-        bigquery.SchemaField("industry", "STRING"),
-        bigquery.SchemaField("industry_group", "STRING"),
+        bigquery.SchemaField("subsector", "STRING"),
         bigquery.SchemaField("country", "STRING"),
         bigquery.SchemaField("market_cap", "INT64"),
         bigquery.SchemaField("long_name", "STRING"),

--- a/tests/test_data_isolation.py
+++ b/tests/test_data_isolation.py
@@ -256,7 +256,7 @@ class TestStrategyFitQueryTenancy:
 
 class TestStrategyFitMatrixBuilder:
     """`_build_strategy_fit_matrix` is dimension-agnostic and is the shared
-    aggregation core for sector / industry / dte / moneyness / market-cap
+    aggregation core for sector / subsector / dte / moneyness / market-cap
     matrices. These tests pin down the contract so a future refactor can't
     silently change cell counts, ordering, or equity-N/A handling."""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Standardize on the finance-industry term **sector → subsector** for the two-level company classification (rather than yfinance's "sector → industry"). Hierarchy and underlying data are unchanged; this is a labeling and naming-consistency change.

## What changed

### Pages and URLs
- `/industries` → `/sectors`. The old URL still resolves via a 301 redirect so existing bookmarks and links keep working.
- Nav (`Breakdowns → Industries`) → `Breakdowns → Sectors`.
- **Positions list:** the "Industry" filter and column are now "Subsector". The old `?industry=` query param is still accepted as an alias for `?subsector=`.
- **Position detail:** the sector / subsector pill now links to `/sectors`.
- **Strategy Fit:** drill dimension `industry` → `subsector`. Old `?dim=industry` URLs still work (mapped to `subsector`).
- FAQ, landing, pricing, and the `deploy.txt` changelog now read "sector & subsector" instead of "sector & industry".

### Data layer (BigQuery / dbt)
- Column `industry` → `subsector` in:
  - `stg_symbol_metadata`
  - `positions_summary`
  - `int_enriched_current`
- The duplicate `industry_group` column is dropped (it was a near-duplicate of the display string of `industry` and wasn't read by the app).
- `scripts/refresh_symbol_metadata.py` now writes the new schema (`symbol, sector, subsector, country, market_cap, long_name, fetched_at`). It still reads yfinance's `industryDisp` / `industry` keys — those are the upstream API contract.

### AI Insights
- `app/strategy_fit_insights.py` now selects `subsector` and the prompt language references "sector / subsector classifications".

## Deploy order

`refresh_symbol_metadata.py` runs **before** the first `dbt build` in both CI (`.github/workflows/bigquery_update.yml`) and locally (`refresh.sh`). It writes with `WRITE_TRUNCATE`, so by the time the dbt models rebuild, the source table is already on the new schema. No backfill or manual migration step is needed.

## Validation

- `dbt parse` succeeds against the renamed models.
- All 86 non-DB unit tests pass, including `TestStrategyFitMatrixBuilder` and `TestStrategyFitQueryTenancy`.
- Flask app boots and registers both `/sectors` (new) and `/industries` (legacy redirect).
- All Jinja templates parse cleanly.

## Backward compatibility

- `/industries` → 301 redirect to `/sectors` (with query string preserved).
- `?industry=...` still accepted on Positions as `?subsector=...`.
- `?dim=industry` still accepted on Strategy Fit as `?dim=subsector`.

These aliases can be removed in a later cleanup once we're confident no external links depend on them.

## Tenancy

No tenancy surface changed. Account scoping in `SECTORS_QUERY` / `STRATEGY_FIT_QUERY` is identical to the previous `INDUSTRIES_QUERY`/`STRATEGY_FIT_QUERY` (same `{account_filter}` placeholder, same `_filter_df_by_accounts` belt on the resulting DataFrame).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-12a16607-813e-449d-ad7c-c875990ea328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-12a16607-813e-449d-ad7c-c875990ea328"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

