### PR TITLE
Remove stale industry wording from sectors template

### DIFF
--- a/app/templates/sectors.html
+++ b/app/templates/sectors.html
@@ -2,9 +2,8 @@
 
 {% block head %}
 <style>
-    /* CSS class names are kept as `.ind-*` (legacy from when this page
-       was called Industries) to keep the diff focused. They now style
-       sector / subsector content; class meaning is internal-only. */
+    /* CSS class names are legacy internal selectors; page copy uses
+       sector / subsector terminology. */
     .ind-hero {
         background: linear-gradient(135deg, #1e1b4b 0%, #4c1d95 100%);
         color: #fff;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Removed a stale template comment that referred to the sectors page as Industries.
- Confirmed visible sector/subsector page copy already uses sector terminology.

## Verification
- `python3 -m compileall app`
- Searched app templates for `industry` / `industries`; only remaining template match is unrelated privacy-policy copy: `industry-standard encryption`.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://happy-trader.slack.com/archives/D0B1PSQA1FT/p1777776764281609?thread_ts=1777776764.281609&cid=D0B1PSQA1FT)

<div><a href="https://cursor.com/agents/bc-deb4bec2-d5bf-551e-adec-bce6d90fec97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-deb4bec2-d5bf-551e-adec-bce6d90fec97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

