### PR TITLE
Hide community surface behind COMMUNITY_ENABLED flag (default off)

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -73,6 +73,7 @@ def _inject_feature_flags():
 
     return {
         "insights_enabled": current_app.config.get("INSIGHTS_ENABLED", True),
+        "community_enabled": current_app.config.get("COMMUNITY_ENABLED", False),
         "is_admin_user": is_admin_user,
         "is_demo_user": is_demo_user(),
         "signup_enabled": current_app.config.get("SIGNUP_ENABLED", True),

--- a/app/profile_community.py
+++ b/app/profile_community.py
@@ -8,6 +8,39 @@ from flask import abort, flash, jsonify, redirect, render_template, request, url
 from flask_login import current_user, login_required
 
 from app import app
+
+# Endpoints that make up the community surface. When COMMUNITY_ENABLED is off
+# every one of these 404s and any leftover link in a template (or external
+# bookmark) becomes a hard "page not found" instead of an empty/broken page.
+# The /profile route itself is *not* in here: it stays usable for preferences,
+# account, security; only the community/published tabs inside profile.html are
+# hidden + redirected (handled below in the GET handler).
+_COMMUNITY_ENDPOINTS = frozenset({
+    "community",
+    "community_post_create",
+    "community_my_trades",
+    "community_post_delete",
+    "community_post_visibility",
+    "public_trader_profile",
+    "follow_trader",
+    "unfollow_trader",
+    "community_publish_trade_route",
+})
+
+
+@app.before_request
+def _require_community_feature():
+    """404 every community endpoint when the feature flag is off.
+
+    Mirrors the pattern used by /insights (`_require_insights_feature` in
+    app/insights.py) so behaviour stays consistent between the two
+    "behind-a-flag while we iterate" surfaces.
+    """
+    if app.config.get("COMMUNITY_ENABLED", False):
+        return None
+    if request.endpoint in _COMMUNITY_ENDPOINTS:
+        abort(404)
+    return None
 from app.bigquery_client import get_bigquery_client
 from app.utils import demo_block_writes
 from app.models import (
@@ -86,6 +119,8 @@ def profile():
     tab = request.args.get("tab", "overview")
     if tab not in ("overview", "preferences", "account", "community", "published"):
         tab = "overview"
+    if tab in ("community", "published") and not app.config.get("COMMUNITY_ENABLED", False):
+        return redirect(url_for("profile", tab="overview"))
 
     if request.method == "POST":
         blocked = demo_block_writes("profile and account settings")
@@ -142,6 +177,8 @@ def profile():
         if action == "save_profile":
             settings_tab = (request.form.get("settings_tab") or "").strip().lower()
             if settings_tab == "community":
+                if not app.config.get("COMMUNITY_ENABLED", False):
+                    abort(404)
                 visibility = (request.form.get("profile_visibility") or "private").strip().lower()
                 if visibility not in _ALLOWED_VISIBILITY:
                     visibility = "private"

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -291,10 +291,12 @@
                         </li>
                     </ul>
                 </li>
+                {% if community_enabled %}
                 <li class="nav-item">
                     <a class="nav-link {% if ep == 'community' %}active{% endif %}"
                        href="{{ url_for('community') }}">Community</a>
                 </li>
+                {% endif %}
                 {% if insights_enabled %}
                 <li class="nav-item">
                     <a class="nav-link {% if ep == 'insights' %}active{% endif %}"

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -135,8 +135,10 @@
             <a class="nav-link {% if tab == 'overview' %}active{% endif %}" href="{{ url_for('profile', tab='overview') }}">Overview</a>
             <a class="nav-link {% if tab == 'account' %}active{% endif %}" href="{{ url_for('profile', tab='account') }}">Accounts &amp; data</a>
             <a class="nav-link {% if tab == 'preferences' %}active{% endif %}" href="{{ url_for('profile', tab='preferences') }}">Preferences</a>
+            {% if community_enabled %}
             <a class="nav-link {% if tab == 'community' %}active{% endif %}" href="{{ url_for('profile', tab='community') }}">Community</a>
             <a class="nav-link {% if tab == 'published' %}active{% endif %}" href="{{ url_for('profile', tab='published') }}">Shared trades</a>
+            {% endif %}
         </nav>
 
         <div>

--- a/app/templates/weekly_review.html
+++ b/app/templates/weekly_review.html
@@ -1216,7 +1216,9 @@
                     <th>Strategy</th>
                     <th>Date</th>
                     <th class="text-end">P&amp;L</th>
+                    {% if community_enabled %}
                     <th class="text-end small" style="white-space:nowrap;min-width:5.5rem"><span class="text-muted">Show</span></th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody>
@@ -1242,6 +1244,7 @@
                     <td class="text-end fw-semibold {% if t.current_pnl is not none %}{% if t.current_pnl >= 0 %}text-positive{% else %}text-negative{% endif %}{% endif %}">
                         {% if t.current_pnl is not none %}{{ "+" if t.current_pnl >= 0 else "" }}${{ "{:,.2f}".format(t.current_pnl) }}{% else %}—{% endif %}
                     </td>
+                    {% if community_enabled %}
                     <td class="text-end">
                         {% if t.trade_fingerprint %}
                         <button type="button" class="btn btn-sm py-1 px-2 rounded-pill {% if t.published_to_community %}wm-wall-done{% else %}wm-wall-btn{% endif %}"
@@ -1261,6 +1264,7 @@
                         </button>
                         {% else %}<span class="small text-muted">—</span>{% endif %}
                     </td>
+                    {% endif %}
                 </tr>
                 {% endfor %}
             </tbody>
@@ -1619,7 +1623,9 @@
                     <th>Strategy</th>
                     <th>Status</th>
                     <th class="text-end">P&amp;L</th>
+                    {% if community_enabled %}
                     <th class="text-end small" style="white-space:nowrap;min-width:5.5rem"><span class="text-muted">Show</span></th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody>
@@ -1637,6 +1643,7 @@
                     <td class="text-end fw-semibold {% if t.current_pnl is not none %}{% if t.current_pnl >= 0 %}text-positive{% else %}text-negative{% endif %}{% endif %}">
                         {% if t.current_pnl is not none %}{{ "+" if t.current_pnl >= 0 else "" }}${{ "{:,.2f}".format(t.current_pnl) }}{% else %}—{% endif %}
                     </td>
+                    {% if community_enabled %}
                     <td class="text-end">
                         {% if t.trade_fingerprint %}
                         <button type="button" class="btn btn-sm py-1 px-2 rounded-pill {% if t.published_to_community %}wm-wall-done{% else %}wm-wall-btn{% endif %}"
@@ -1656,6 +1663,7 @@
                         </button>
                         {% else %}<span class="small text-muted">—</span>{% endif %}
                     </td>
+                    {% endif %}
                 </tr>
                 {% endfor %}
             </tbody>
@@ -1667,6 +1675,8 @@
 
 {% endif %}{# end midweek #}
 
+{% if community_enabled %}
 {% include "_community_trade_modal.html" %}
+{% endif %}
 
 {% endblock %}

--- a/config.py
+++ b/config.py
@@ -66,6 +66,17 @@ class Config:
     # dataset is still being backfilled/tuned.
     BEHAVIOR_INSIGHTS_ENABLED = _env_bool("BEHAVIOR_INSIGHTS_ENABLED", "true")
 
+    # Community surface (followers, posts, public profiles, "Show" trade publish).
+    # Default OFF: the trading-mirror identity is single-player and the community
+    # surface still needs notifications, moderation, seeding, and on-strategy
+    # redesign before it should ship to real users. Code, schema, and routes
+    # stay in the repo so iteration can continue behind the flag — set
+    # COMMUNITY_ENABLED=1 to turn it back on (e.g. local dev, internal preview).
+    # When OFF: the /community, /u/<username>, /community/* routes 404, the
+    # Community nav link + Profile tabs disappear, and the Weekly Review "Show"
+    # column + publish modal are not rendered. Tests force-enable in conftest.
+    COMMUNITY_ENABLED = _env_bool("COMMUNITY_ENABLED", "false")
+
     # CSV uploads (manual upload page). Prevents accidental huge POSTs.
     _max_mb = int(os.environ.get("MAX_UPLOAD_MB", "32"))
     MAX_CONTENT_LENGTH = _max_mb * 1024 * 1024

--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,7 @@ def app():
     flask_app.config["RATELIMIT_ENABLED"] = False
     flask_app.config["SESSION_IDLE_TIMEOUT_MINUTES"] = 0
     flask_app.config["INSIGHTS_ENABLED"] = True
+    flask_app.config["COMMUNITY_ENABLED"] = True
     return flask_app
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

The community surface (followers, posts, public trader profiles, weekly-review "Show" publish flow) is feature-complete but still **early**. To ship it for real we still need notifications, moderation, abuse handling, seeding, and an on-strategy redesign of the rest of the app so the social layer doesn't feel disjointed.

`AGENTS.md` is explicit that the product identity is a single-player **Trading Mirror** ("we compare traders to themselves, not to others"). Surfacing this half-built social layer in production sets the wrong expectation and locks us into a second product axis we don't actually want to commit to yet. This PR puts the whole surface behind a flag so iteration can continue without exposing it to users.

## What

Mirror the exact pattern used by `INSIGHTS_ENABLED`:

- **`config.py`** — new `COMMUNITY_ENABLED` env flag, default `false` in prod. Set `COMMUNITY_ENABLED=1` to bring it back (local dev, internal preview, when ready to ship).
- **`conftest.py`** — tests force-enable so existing community helpers and tenant-isolation tests keep exercising the code.
- **`app/__init__.py`** — exposes `community_enabled` to all templates via the existing `_inject_feature_flags` context processor.
- **`app/profile_community.py`** — `before_request` guard 404s every community endpoint when the flag is off:
  - `community`, `community_post_create`, `community_post_delete`, `community_post_visibility`
  - `community_my_trades`, `community_publish_trade_route`
  - `public_trader_profile`, `follow_trader`, `unfollow_trader`
- **`/profile?tab=community`** and **`tab=published`** silently redirect to the overview tab; the `save_profile` POST for the community tab `abort(404)`s defensively too.
- **`app/templates/base.html`** — hides the **Community** nav link.
- **`app/templates/profile.html`** — hides the **Community** + **Shared trades** sidebar tabs.
- **`app/templates/weekly_review.html`** — drops the **Show** column header + publish button in both the Friday "All Trades This Week" and the mid-week "Trades This Week" tables, and skips the `_community_trade_modal.html` include.

## What is **not** changed

- `community_posts`, `community_published_trades`, `user_follows`, `community_published_trades`, and the `profile_visibility` / `show_account_names_on_published` columns all stay in `users_profile`. No data is dropped.
- Source files (`app/profile_community.py`, `app/templates/community.html`, `app/templates/_community_trade_modal.html`, `app/templates/_show_wall_strip_weekly.html`, `app/templates/user_public.html`) all stay in the repo.
- All `app/models.py` helpers (`follow_user`, `community_feed`, `publish_community_trade`, etc.) stay in place — tests still cover them, the admin user list still reads from `community_posts`, and turning the flag back on is one env var.

## Verification

```text
COMMUNITY_ENABLED=0  →  GET  /community                 404
COMMUNITY_ENABLED=0  →  GET  /u/foo                     404
COMMUNITY_ENABLED=0  →  POST /community/post            404
COMMUNITY_ENABLED=0  →  GET  /community/my-trades       404
COMMUNITY_ENABLED=0  →  POST /community/publish-trade   404
COMMUNITY_ENABLED=0  →  POST /u/foo/follow              404
COMMUNITY_ENABLED=0  →  POST /u/foo/unfollow            404
COMMUNITY_ENABLED=0  →  POST /community/post/1/delete   404
COMMUNITY_ENABLED=0  →  POST /community/post/1/visibility  404
COMMUNITY_ENABLED=0  →  GET  /profile?tab=community     302 → /profile?tab=overview
COMMUNITY_ENABLED=0  →  GET  /profile?tab=published     302 → /profile?tab=overview
COMMUNITY_ENABLED=0  →  GET  /                          200
COMMUNITY_ENABLED=1  →  GET  /community                 302 → /login (normal login-required behavior)
```

`pytest tests/` (without `TEST_DATABASE_URL`): **90 passed, 32 skipped** (DB-dependent), no regressions. All touched templates parse cleanly via Flask's Jinja env.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a067c1d-edc7-433d-b204-1b8576cf6990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a067c1d-edc7-433d-b204-1b8576cf6990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

