### PR TITLE
Fix Actions install: bump typing_extensions to 4.13.2 for snaptrade-python-sdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,7 @@ six==1.17.0
 snowplow-tracker==1.1.0
 sqlparse==0.5.3
 text-unidecode==1.3
-typing_extensions==4.12.2
+typing_extensions==4.13.2
 tzdata==2025.1
 urllib3>=2.6.3
 Werkzeug==3.1.3


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What broke

The `Update Daily Position Performance` workflow has been failing on the **Install Python dependencies** step:

```
The conflict is caused by:
    The user requested typing_extensions==4.12.2
    snaptrade-python-sdk 11.0.194 depends on typing_extensions<5 and >=4.13.2
    snaptrade-python-sdk 11.0.193 depends on typing_extensions<5 and >=4.13.2
    snaptrade-python-sdk 11.0.192 depends on typing_extensions<5 and >=4.13.2
    snaptrade-python-sdk 11.0.191 depends on typing_extensions==4.13.2
ERROR: ResolutionImpossible
```

`requirements.txt` pins `snaptrade-python-sdk<12,>=11.0.191` (added with the SnapTrade integration), and every published `snaptrade-python-sdk` in that range now requires `typing_extensions>=4.13.2`. Our pin at `4.12.2` made pip's resolver give up, and every subsequent CI step (`Set up DBT profiles`, `Run DBT build`, etc.) was skipped — which is what the screenshot was showing.

## Fix

Bump `typing_extensions` from `4.12.2` → `4.13.2`. Every other package in `requirements.txt` allows it (the strictest lower bounds elsewhere are `>=4.4` for dbt-core / dbt-common / dbt-adapters / dbt-semantic-interfaces, and `>=4.12.2` for pydantic).

## Verification

- Run resolved cleanly locally against the same constraints.
- No code changes; this is a single-line pin bump.
- Once merged, the next push to `master` should let `Install Python dependencies` finish and the rest of the bigquery_update workflow run again.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ae06625-51dd-4cf1-89b4-9970a523a597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ae06625-51dd-4cf1-89b4-9970a523a597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

