### PR TITLE
Surface preferred-share dividends (GLOP-C and friends) by adding a Yahoo symbol fallback

### DIFF
--- a/current_position_stock_price.py
+++ b/current_position_stock_price.py
@@ -1,221 +1,331 @@
+import re
 import pandas as pd
 import yfinance as yf
 from datetime import date, timedelta
 from google.cloud import bigquery
 
-# Step 1: Initialize BigQuery client
-client = bigquery.Client()
 
-# Step 2: Query BigQuery to get all traded underlyings (equity AND option positions)
-# so we also have stock prices for symbols held only as options.
-query = """
-    SELECT account, user_id, underlying_symbol AS symbol, MIN(trade_date) AS position_open_date
-    FROM `ccwj-dbt.analytics.stg_history`
-    WHERE underlying_symbol IS NOT NULL
-    GROUP BY 1, 2, 3
-"""
-positions = client.query(query).result()
-positions_df = pd.DataFrame([dict(row.items()) for row in positions])
-
-# Step 2b: Add benchmark tickers (SPY, QQQ) so weekly review can skip live yfinance.
-# We mint one benchmark row per (account, user_id) so prices propagate to every
-# tenant — see docs/USER_ID_TENANCY.md.
-BENCHMARK_TICKERS = ["SPY", "QQQ"]
-benchmark_start = date(date.today().year, 1, 1)
-benchmark_rows = []
-if not positions_df.empty:
-    tenant_pairs = positions_df[["account", "user_id"]].drop_duplicates().to_records(index=False)
-else:
-    tenant_pairs = [("_benchmark", None)]
-for account, user_id in tenant_pairs:
-    for sym in BENCHMARK_TICKERS:
-        already_present = not positions_df.empty and (
-            (positions_df["symbol"] == sym)
-            & (positions_df["account"] == account)
-            & (positions_df["user_id"].astype("object") == user_id)
-        ).any()
-        if not already_present:
-            benchmark_rows.append({
-                "account": account,
-                "user_id": user_id,
-                "symbol": sym,
-                "position_open_date": benchmark_start,
-            })
-if benchmark_rows:
-    positions_df = pd.concat(
-        [positions_df, pd.DataFrame(benchmark_rows)], ignore_index=True
-    )
-
-# Step 3: Collect daily price & dividend data
-today = date.today()
-# yfinance's end is exclusive, so use tomorrow to include today's close price
-end_date = (today + timedelta(days=1)).isoformat()
-all_data = []
-
-# Stock-split ledger. Per-symbol (de-duplicated below) so a single split
-# event is not written N times when the same symbol appears across many
-# (account, user_id) pairs. Schema: (symbol, split_date, split_ratio).
+# ---------------------------------------------------------------------------
+# Yahoo symbol mapping
+# ---------------------------------------------------------------------------
+# Brokers and Yahoo use different conventions for some equity classes.
+# Most notably PREFERRED SHARES: Schwab's API returns a preferred series
+# as ``<root>-<class>`` (e.g. GLOP/PRC → ``GLOP-C`` in the API), but
+# Yahoo's symbol for the same security is ``<root>-P<class>``
+# (``GLOP-PC``). Dual-class COMMON shares like Berkshire Class B and
+# Brown-Forman Class B use the broker form on Yahoo too (``BRK-B``,
+# ``BF-B`` both resolve), so we cannot blindly inject the ``P``.
 #
-# yfinance's `ticker.splits` ratio convention: 2.0 for a 2:1 forward
-# split (1 share becomes 2), 0.0333 for a 1:30 reverse (30 shares
-# become 1). Apply forward to all trades BEFORE split_date to express
-# pre-split fills in the same share-unit as the post-split snapshot.
-# `int_split_factors` does the cumulative product downstream.
+# The collision is real. ``XYZ-C`` could be either:
+#   * a third class of common stock (rare; Yahoo: ``XYZ-C``)
+#   * a preferred series C  (common; Yahoo: ``XYZ-PC``)
+# We cannot tell from the broker symbol alone — Schwab strips the ``PR``
+# from ``XYZ/PRC`` and gives us only ``XYZ-C``. So we try the broker
+# form first; if that returns no data we fall back to the preferred-
+# style ``<root>-P<class>``. Worst case for a delisted symbol: one
+# extra HTTP roundtrip per cron run.
 #
-# Why a separate table (vs. piggybacking daily_position_performance):
-# splits are SYMBOL-grain, not (account, user_id, symbol, date)-grain.
-# Splitting them onto the per-tenant per-day table wastes ~10x rows
-# and forces split-adjustment models into ``stg_daily_prices+`` (the
-# CI two-pass build's pass-2 bucket). Keeping them in their own source
-# means `int_split_factors` builds in pass 1 alongside `int_equity_sessions`,
-# which is where split-adjusted running quantities matter most.
-splits_seen = {}  # (symbol, split_date) -> split_ratio (last write wins)
+# Why this matters: when the primary symbol returns no data, NOTHING
+# downstream of ``daily_position_performance`` (price, dividends,
+# splits) reaches the user. The synthetic dividend path in
+# ``int_dividend_events.sql`` multiplies ``shares_held × div_per_share``
+# from ``stg_daily_prices``, so an empty Yahoo fetch silently zeros out
+# every dividend on the position. (May 2026 GLOP-C: position showed
+# $0.00 in dividends despite the user receiving $2,809.76 in qualified
+# dividends per the Schwab transaction history.)
 
-for _, row in positions_df.iterrows():
-    account = row["account"]
-    user_id = row["user_id"] if "user_id" in row else None
-    symbol = row["symbol"]
-    start_date = row["position_open_date"].isoformat()
+_PREFERRED_CANDIDATE_RE = re.compile(r"^([A-Z][A-Z0-9.]{0,5})-([A-Z])$")
 
-    try:
-        ticker = yf.Ticker(symbol)
-        hist = ticker.history(start=start_date, end=end_date)
 
-        # Undo yfinance's split back-adjustment.
-        #
-        # yfinance always returns historical close prices retroactively
-        # adjusted for splits — pre-split prices are scaled so that they
-        # are directly comparable, on a per-current-share basis, to
-        # post-split prices. For a 1-for-30 reverse split this means
-        # pre-split closes are *multiplied* by 30 (because 1 new share
-        # represents 30 old shares); two consecutive 1-for-30 reverse
-        # splits inflate pre-split closes by 900×.
-        #
-        # That convention is the wrong default for us because our share
-        # ledger is built from raw broker tickets (``stg_history``), not
-        # from current-shares. Marking 8000 raw RVSN shares against a
-        # back-adjusted $2,214 close produced a $17.7M phantom equity
-        # peak on the /accounts chart (real peak ~$10K). The user never
-        # held shares at $2,214 — that's just yfinance reverse-engineering
-        # 2026 splits onto 2024 prices.
-        #
-        # Fix: multiply each historical close by the product of split
-        # ratios for splits that occur AFTER its date. For RVSN on
-        # 2024-12-30 the future ratios are 0.033333 × 0.033333 ≈
-        # 0.001111 → raw close $2.46. For dates after all known splits
-        # (or for symbols with no splits) the factor is 1 and we keep
-        # whatever yfinance returned. Dividends from yfinance are not
-        # consumed downstream (mart_daily_pnl reads them from
-        # stg_history), so we leave the Dividends column alone.
+def _yahoo_symbol_candidates(broker_sym):
+    """Return ordered list of Yahoo-symbol candidates to try for one broker symbol.
+
+    The first non-empty history wins; the loader writes rows back under
+    the original ``broker_sym`` so downstream joins on
+    ``underlying_symbol`` keep working unchanged.
+    """
+    if not isinstance(broker_sym, str):
+        return []
+    sym = broker_sym.strip()
+    if not sym:
+        return []
+    candidates = [sym]
+    m = _PREFERRED_CANDIDATE_RE.match(sym)
+    if m and not sym.startswith(m.group(1) + "-P"):
+        candidates.append(f"{m.group(1)}-P{m.group(2)}")
+    return candidates
+
+
+def _fetch_history_for_symbol(broker_sym, start_iso, end_iso):
+    """Fetch ``(history_df, ticker_used, yahoo_symbol_used)`` for one symbol.
+
+    Returns ``(None, None, None)`` when no candidate yields any rows.
+    Caller is responsible for the split-adjust pass and the rename/
+    write-back into ``daily_position_performance`` under ``broker_sym``.
+    """
+    last_err = None
+    for cand in _yahoo_symbol_candidates(broker_sym):
         try:
-            splits = ticker.splits
-        except Exception:
-            splits = None
-        if splits is not None and len(splits) and not hist.empty:
-            split_dates = list(splits.index)
-            split_ratios = [float(r) for r in splits.values]
-            close = hist["Close"].astype(float).copy()
-            hist_dates = hist.index
-            for sd, ratio in zip(split_dates, split_ratios):
-                if not (ratio > 0):
-                    continue
-                # Compare CALENDAR DATES, not timestamps. yfinance ships
-                # split timestamps at 09:30 ET (the moment of the split,
-                # at market open) while history rows are indexed at
-                # midnight ET. A naive ``hist_dates < sd`` comparison
-                # treats the split-day close (4:00 PM ET) as pre-split
-                # and incorrectly multiplies it by the ratio — producing
-                # a one-day chart spike (May 2026 XLU: 2025-12-05 close
-                # stored as $85.36 instead of the actual $42.68 post-
-                # split close, drawing a $137K MTM cliff on the chart
-                # for a single day). yfinance already returns the close
-                # in POST-split units on the split day itself; only
-                # PRE-split-DATE closes need un-adjustment.
-                try:
-                    sd_date = sd.date() if hasattr(sd, "date") else sd
-                except Exception:
-                    sd_date = sd
-                mask = pd.Series(hist_dates).dt.date < sd_date
-                mask.index = hist_dates
-                if mask.any():
-                    close.loc[mask] = close.loc[mask] * ratio
-                # Record this split for the daily_split_events table.
-                # Same symbol may iterate many times (one per tenant) —
-                # dict de-dup ensures one row per (symbol, split_date).
-                splits_seen[(symbol, sd_date)] = ratio
-            hist["Close"] = close
+            t = yf.Ticker(cand)
+            h = t.history(start=start_iso, end=end_iso)
+        except Exception as e:
+            last_err = e
+            continue
+        if h is not None and not h.empty:
+            if cand != broker_sym:
+                print(
+                    f"Yahoo symbol fallback for {broker_sym!r}: using {cand!r} "
+                    f"({len(h)} rows)."
+                )
+            return h, t, cand
+    if last_err is not None:
+        print(f"Error fetching data for {broker_sym}: {last_err}")
+    return None, None, None
 
-        hist = hist[["Close", "Dividends"]].reset_index()
-        hist["account"] = account
-        hist["user_id"] = user_id
-        hist["symbol"] = symbol
-        hist.rename(columns={"Date": "date", "Close": "close_price", "Dividends": "dividend"}, inplace=True)
 
-        # Ensure we're only keeping data from on/after position_open_date
-        hist = hist[hist["date"].dt.date >= row["position_open_date"]]
+# ---------------------------------------------------------------------------
+# Main script body
+# ---------------------------------------------------------------------------
+# Guarded by ``if __name__ == "__main__"`` so unit tests can import the
+# helper functions above (``_yahoo_symbol_candidates``,
+# ``_fetch_history_for_symbol``) without triggering BigQuery client
+# construction. Pre-guard the import did:
+#   - top-level ``client = bigquery.Client()``  → ADC required
+#   - top-level ``client.query(...).result()``  → live BQ query
+# Both made the test module uncollectable when running outside CI.
+def _main():
+    # Step 1: Initialize BigQuery client
+    client = bigquery.Client()
 
-        all_data.append(hist)
-    except Exception as e:
-        print(f"Error fetching data for {symbol}: {e}")
+    # Step 2: Query BigQuery to get all traded underlyings (equity AND option positions)
+    # so we also have stock prices for symbols held only as options.
+    query = """
+        SELECT account, user_id, underlying_symbol AS symbol, MIN(trade_date) AS position_open_date
+        FROM `ccwj-dbt.analytics.stg_history`
+        WHERE underlying_symbol IS NOT NULL
+        GROUP BY 1, 2, 3
+    """
+    positions = client.query(query).result()
+    positions_df = pd.DataFrame([dict(row.items()) for row in positions])
 
-# Step 4: Upload results to BigQuery
-if all_data:
-    final_df = pd.concat(all_data, ignore_index=True)
-    # user_id round-trips through pandas as object/Int64; coerce to nullable Int64
-    # so BigQuery loads it cleanly as INT64 NULLABLE alongside legacy NULL rows.
-    final_df["user_id"] = pd.to_numeric(final_df["user_id"], errors="coerce").astype("Int64")
-    final_df = final_df[["account", "user_id", "symbol", "date", "close_price", "dividend"]]
+    # Step 2b: Add benchmark tickers (SPY, QQQ) so weekly review can skip live yfinance.
+    # We mint one benchmark row per (account, user_id) so prices propagate to every
+    # tenant — see docs/USER_ID_TENANCY.md.
+    BENCHMARK_TICKERS = ["SPY", "QQQ"]
+    benchmark_start = date(date.today().year, 1, 1)
+    benchmark_rows = []
+    if not positions_df.empty:
+        tenant_pairs = positions_df[["account", "user_id"]].drop_duplicates().to_records(index=False)
+    else:
+        tenant_pairs = [("_benchmark", None)]
+    for account, user_id in tenant_pairs:
+        for sym in BENCHMARK_TICKERS:
+            already_present = not positions_df.empty and (
+                (positions_df["symbol"] == sym)
+                & (positions_df["account"] == account)
+                & (positions_df["user_id"].astype("object") == user_id)
+            ).any()
+            if not already_present:
+                benchmark_rows.append({
+                    "account": account,
+                    "user_id": user_id,
+                    "symbol": sym,
+                    "position_open_date": benchmark_start,
+                })
+    if benchmark_rows:
+        positions_df = pd.concat(
+            [positions_df, pd.DataFrame(benchmark_rows)], ignore_index=True
+        )
 
-    table_id = "ccwj-dbt.analytics.daily_position_performance"
-    final_df = final_df.drop_duplicates()
-    job = client.load_table_from_dataframe(
-        final_df,
-        table_id,
-        job_config=bigquery.LoadJobConfig(write_disposition="WRITE_TRUNCATE")
+    # Step 3: Collect daily price & dividend data
+    today = date.today()
+    # yfinance's end is exclusive, so use tomorrow to include today's close price
+    end_date = (today + timedelta(days=1)).isoformat()
+    all_data = []
+
+    # Stock-split ledger. Per-symbol (de-duplicated below) so a single split
+    # event is not written N times when the same symbol appears across many
+    # (account, user_id) pairs. Schema: (symbol, split_date, split_ratio).
+    #
+    # yfinance's `ticker.splits` ratio convention: 2.0 for a 2:1 forward
+    # split (1 share becomes 2), 0.0333 for a 1:30 reverse (30 shares
+    # become 1). Apply forward to all trades BEFORE split_date to express
+    # pre-split fills in the same share-unit as the post-split snapshot.
+    # `int_split_factors` does the cumulative product downstream.
+    #
+    # Why a separate table (vs. piggybacking daily_position_performance):
+    # splits are SYMBOL-grain, not (account, user_id, symbol, date)-grain.
+    # Splitting them onto the per-tenant per-day table wastes ~10x rows
+    # and forces split-adjustment models into ``stg_daily_prices+`` (the
+    # CI two-pass build's pass-2 bucket). Keeping them in their own source
+    # means `int_split_factors` builds in pass 1 alongside `int_equity_sessions`,
+    # which is where split-adjusted running quantities matter most.
+    splits_seen = {}  # (symbol, split_date) -> split_ratio (last write wins)
+
+    for _, row in positions_df.iterrows():
+        account = row["account"]
+        user_id = row["user_id"] if "user_id" in row else None
+        symbol = row["symbol"]
+        start_date = row["position_open_date"].isoformat()
+
+        try:
+            # Some preferred-share symbols (e.g. Schwab "GLOP-C") return no
+            # data when queried under the broker form because Yahoo uses
+            # "<root>-P<class>" for preferreds (e.g. "GLOP-PC"). The helper
+            # tries the broker form first, then falls back to the preferred
+            # form — see ``_yahoo_symbol_candidates``. Rows are still
+            # written back keyed on the broker symbol so downstream joins
+            # (``stg_history.underlying_symbol`` → ``stg_daily_prices.symbol``)
+            # don't need to know about the Yahoo translation.
+            hist, ticker, yahoo_sym = _fetch_history_for_symbol(
+                symbol, start_date, end_date
+            )
+            if hist is None or hist.empty:
+                print(
+                    f"No yfinance data for {symbol} (start={start_date}, "
+                    f"end={end_date}); skipping."
+                )
+                continue
+
+            # Undo yfinance's split back-adjustment.
+            #
+            # yfinance always returns historical close prices retroactively
+            # adjusted for splits — pre-split prices are scaled so that they
+            # are directly comparable, on a per-current-share basis, to
+            # post-split prices. For a 1-for-30 reverse split this means
+            # pre-split closes are *multiplied* by 30 (because 1 new share
+            # represents 30 old shares); two consecutive 1-for-30 reverse
+            # splits inflate pre-split closes by 900×.
+            #
+            # That convention is the wrong default for us because our share
+            # ledger is built from raw broker tickets (``stg_history``), not
+            # from current-shares. Marking 8000 raw RVSN shares against a
+            # back-adjusted $2,214 close produced a $17.7M phantom equity
+            # peak on the /accounts chart (real peak ~$10K). The user never
+            # held shares at $2,214 — that's just yfinance reverse-engineering
+            # 2026 splits onto 2024 prices.
+            #
+            # Fix: multiply each historical close by the product of split
+            # ratios for splits that occur AFTER its date. For RVSN on
+            # 2024-12-30 the future ratios are 0.033333 × 0.033333 ≈
+            # 0.001111 → raw close $2.46. For dates after all known splits
+            # (or for symbols with no splits) the factor is 1 and we keep
+            # whatever yfinance returned. Dividends from yfinance are not
+            # consumed downstream (mart_daily_pnl reads them from
+            # stg_history), so we leave the Dividends column alone.
+            try:
+                splits = ticker.splits
+            except Exception:
+                splits = None
+            if splits is not None and len(splits) and not hist.empty:
+                split_dates = list(splits.index)
+                split_ratios = [float(r) for r in splits.values]
+                close = hist["Close"].astype(float).copy()
+                hist_dates = hist.index
+                for sd, ratio in zip(split_dates, split_ratios):
+                    if not (ratio > 0):
+                        continue
+                    # Compare CALENDAR DATES, not timestamps. yfinance ships
+                    # split timestamps at 09:30 ET (the moment of the split,
+                    # at market open) while history rows are indexed at
+                    # midnight ET. A naive ``hist_dates < sd`` comparison
+                    # treats the split-day close (4:00 PM ET) as pre-split
+                    # and incorrectly multiplies it by the ratio — producing
+                    # a one-day chart spike (May 2026 XLU: 2025-12-05 close
+                    # stored as $85.36 instead of the actual $42.68 post-
+                    # split close, drawing a $137K MTM cliff on the chart
+                    # for a single day). yfinance already returns the close
+                    # in POST-split units on the split day itself; only
+                    # PRE-split-DATE closes need un-adjustment.
+                    try:
+                        sd_date = sd.date() if hasattr(sd, "date") else sd
+                    except Exception:
+                        sd_date = sd
+                    mask = pd.Series(hist_dates).dt.date < sd_date
+                    mask.index = hist_dates
+                    if mask.any():
+                        close.loc[mask] = close.loc[mask] * ratio
+                    # Record this split for the daily_split_events table.
+                    # Same symbol may iterate many times (one per tenant) —
+                    # dict de-dup ensures one row per (symbol, split_date).
+                    splits_seen[(symbol, sd_date)] = ratio
+                hist["Close"] = close
+
+            hist = hist[["Close", "Dividends"]].reset_index()
+            hist["account"] = account
+            hist["user_id"] = user_id
+            hist["symbol"] = symbol
+            hist.rename(columns={"Date": "date", "Close": "close_price", "Dividends": "dividend"}, inplace=True)
+
+            # Ensure we're only keeping data from on/after position_open_date
+            hist = hist[hist["date"].dt.date >= row["position_open_date"]]
+
+            all_data.append(hist)
+        except Exception as e:
+            print(f"Error fetching data for {symbol}: {e}")
+
+    # Step 4: Upload results to BigQuery
+    if all_data:
+        final_df = pd.concat(all_data, ignore_index=True)
+        # user_id round-trips through pandas as object/Int64; coerce to nullable Int64
+        # so BigQuery loads it cleanly as INT64 NULLABLE alongside legacy NULL rows.
+        final_df["user_id"] = pd.to_numeric(final_df["user_id"], errors="coerce").astype("Int64")
+        final_df = final_df[["account", "user_id", "symbol", "date", "close_price", "dividend"]]
+
+        table_id = "ccwj-dbt.analytics.daily_position_performance"
+        final_df = final_df.drop_duplicates()
+        job = client.load_table_from_dataframe(
+            final_df,
+            table_id,
+            job_config=bigquery.LoadJobConfig(write_disposition="WRITE_TRUNCATE")
+        )
+        job.result()  # Waits for the job to complete
+        print("Upload successful.")
+    else:
+        print("No data to upload.")
+
+    # Step 5: Upload stock-split events to BigQuery (separate table).
+    #
+    # WRITE_TRUNCATE on every run so a yfinance correction (e.g. retroactively
+    # de-listed split, mis-reported ratio) self-heals without manual cleanup.
+    # Schema is symbol-grain (no account/user_id) — splits are corporate
+    # actions and apply identically to every tenant who held the symbol.
+    splits_table_id = "ccwj-dbt.analytics.daily_split_events"
+    if splits_seen:
+        splits_df = pd.DataFrame(
+            [
+                {"symbol": sym, "split_date": sd, "split_ratio": float(ratio)}
+                for (sym, sd), ratio in splits_seen.items()
+                if ratio is not None and float(ratio) > 0
+            ]
+        )
+    else:
+        # Always emit an EMPTY table so the dbt source registration has a
+        # relation to bind to on first deploy. Without this, the very first
+        # CI build of a fresh deploy would fail when stg_split_events tries
+        # to read a non-existent table.
+        splits_df = pd.DataFrame(
+            columns=["symbol", "split_date", "split_ratio"]
+        )
+
+    if not splits_df.empty:
+        splits_df["split_date"] = pd.to_datetime(splits_df["split_date"]).dt.date
+
+    splits_job = client.load_table_from_dataframe(
+        splits_df,
+        splits_table_id,
+        job_config=bigquery.LoadJobConfig(
+            write_disposition="WRITE_TRUNCATE",
+            schema=[
+                bigquery.SchemaField("symbol", "STRING"),
+                bigquery.SchemaField("split_date", "DATE"),
+                bigquery.SchemaField("split_ratio", "FLOAT64"),
+            ],
+        ),
     )
-    job.result()  # Waits for the job to complete
-    print("Upload successful.")
-else:
-    print("No data to upload.")
+    splits_job.result()
+    print(f"Uploaded {len(splits_df)} split event(s) to {splits_table_id}.")
 
-# Step 5: Upload stock-split events to BigQuery (separate table).
-#
-# WRITE_TRUNCATE on every run so a yfinance correction (e.g. retroactively
-# de-listed split, mis-reported ratio) self-heals without manual cleanup.
-# Schema is symbol-grain (no account/user_id) — splits are corporate
-# actions and apply identically to every tenant who held the symbol.
-splits_table_id = "ccwj-dbt.analytics.daily_split_events"
-if splits_seen:
-    splits_df = pd.DataFrame(
-        [
-            {"symbol": sym, "split_date": sd, "split_ratio": float(ratio)}
-            for (sym, sd), ratio in splits_seen.items()
-            if ratio is not None and float(ratio) > 0
-        ]
-    )
-else:
-    # Always emit an EMPTY table so the dbt source registration has a
-    # relation to bind to on first deploy. Without this, the very first
-    # CI build of a fresh deploy would fail when stg_split_events tries
-    # to read a non-existent table.
-    splits_df = pd.DataFrame(
-        columns=["symbol", "split_date", "split_ratio"]
-    )
 
-if not splits_df.empty:
-    splits_df["split_date"] = pd.to_datetime(splits_df["split_date"]).dt.date
-
-splits_job = client.load_table_from_dataframe(
-    splits_df,
-    splits_table_id,
-    job_config=bigquery.LoadJobConfig(
-        write_disposition="WRITE_TRUNCATE",
-        schema=[
-            bigquery.SchemaField("symbol", "STRING"),
-            bigquery.SchemaField("split_date", "DATE"),
-            bigquery.SchemaField("split_ratio", "FLOAT64"),
-        ],
-    ),
-)
-splits_job.result()
-print(f"Uploaded {len(splits_df)} split event(s) to {splits_table_id}.")
+if __name__ == "__main__":
+    _main()

--- a/tests/test_yfinance_symbol_candidates.py
+++ b/tests/test_yfinance_symbol_candidates.py
@@ -1,0 +1,177 @@
+"""Tests for the Yahoo-symbol candidate translation in the yfinance loader.
+
+Schwab's API normalises a preferred series like ``GLOP/PRC`` down to the
+broker form ``GLOP-C``. Yahoo Finance uses ``GLOP-PC`` for the same
+security (the ``P`` prefix marks it as a preferred class, vs a
+dual-class common share like Berkshire's ``BRK-B``).
+
+When the loader queries Yahoo with the broker form for a preferred-class
+ticker the response is empty, which silently zeros out the synthetic
+dividend stream in ``int_dividend_events.sql`` (``stg_daily_prices`` has
+no rows so ``shares_held × div_per_share`` is 0). The user's
+``/position/GLOP-C`` page rendered ``$0.00`` in dividends despite
+receiving $2,809.76 in qualified dividends per the Schwab statement.
+
+The fix lives in ``current_position_stock_price._yahoo_symbol_candidates``:
+return the broker form first, then a ``<root>-P<class>`` fallback when
+the broker form looks like a single-letter class suffix.
+"""
+from __future__ import annotations
+
+import pytest
+
+from current_position_stock_price import _yahoo_symbol_candidates
+
+
+class TestPreferredFallback:
+    """Symbols matching ``<root>-<single-letter>`` get a ``-P<letter>`` alt."""
+
+    def test_glop_c_falls_back_to_glop_pc(self):
+        # The canonical regression case (GLOP/PRC preferred series C):
+        # Schwab → "GLOP-C"; Yahoo → "GLOP-PC".
+        cands = _yahoo_symbol_candidates("GLOP-C")
+        assert cands[0] == "GLOP-C"
+        assert "GLOP-PC" in cands
+
+    def test_brk_b_includes_brk_pb_fallback(self):
+        # BRK-B works directly on Yahoo so the fallback is never hit at
+        # runtime — but the candidate list still includes BRK-PB as a
+        # cheap defensive alt. The loader only uses the alt if the
+        # primary returns no rows, so producing this list is safe for
+        # dual-class common shares too.
+        cands = _yahoo_symbol_candidates("BRK-B")
+        assert cands[0] == "BRK-B"
+        assert "BRK-PB" in cands
+
+    def test_already_preferred_form_does_not_double_prefix(self):
+        # If a broker (e.g. SnapTrade) already ships the Yahoo-style
+        # preferred form, don't append a second "P".
+        cands = _yahoo_symbol_candidates("GLOP-PC")
+        assert cands == ["GLOP-PC"]
+
+
+class TestNonPreferred:
+    """Plain tickers and option underlyings yield a single candidate."""
+
+    def test_plain_equity_has_no_alt(self):
+        assert _yahoo_symbol_candidates("AAPL") == ["AAPL"]
+
+    def test_etf_has_no_alt(self):
+        assert _yahoo_symbol_candidates("JEPI") == ["JEPI"]
+
+    def test_two_char_suffix_has_no_alt(self):
+        # The preferred-share pattern is ``<root>-<single letter>``. A
+        # two-letter suffix isn't ambiguous (e.g. crypto/forex shapes)
+        # so we don't add a fallback.
+        assert _yahoo_symbol_candidates("FOO-BB") == ["FOO-BB"]
+
+
+class TestEdgeCases:
+    def test_empty_string_returns_empty(self):
+        assert _yahoo_symbol_candidates("") == []
+
+    def test_whitespace_stripped(self):
+        assert _yahoo_symbol_candidates("  AAPL  ") == ["AAPL"]
+
+    def test_none_returns_empty(self):
+        assert _yahoo_symbol_candidates(None) == []
+
+    def test_non_string_returns_empty(self):
+        assert _yahoo_symbol_candidates(123) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end fetch with mocked yfinance — exercises the candidate loop
+# without touching the network. Pin the "preferred series returns empty
+# under broker form → fallback to <root>-P<class> wins" behaviour so a
+# refactor doesn't quietly drop the fallback and zero out dividends again.
+# ---------------------------------------------------------------------------
+
+
+class _FakeTicker:
+    def __init__(self, hist_df):
+        self._hist = hist_df
+
+    def history(self, start, end):
+        return self._hist
+
+
+class TestFetchHistoryForSymbol:
+    def test_preferred_fallback_wins_when_broker_form_empty(self, monkeypatch):
+        import pandas as pd
+
+        from current_position_stock_price import _fetch_history_for_symbol
+
+        empty = pd.DataFrame()
+        non_empty = pd.DataFrame(
+            {"Close": [25.0, 25.1], "Dividends": [0.0, 0.6]},
+            index=pd.to_datetime(["2024-08-01", "2024-09-09"]),
+        )
+
+        calls = []
+
+        def fake_ticker(sym):
+            calls.append(sym)
+            if sym == "GLOP-C":
+                return _FakeTicker(empty)
+            if sym == "GLOP-PC":
+                return _FakeTicker(non_empty)
+            raise AssertionError(f"unexpected symbol {sym!r}")
+
+        monkeypatch.setattr("current_position_stock_price.yf.Ticker", fake_ticker)
+
+        hist, ticker, yahoo_sym = _fetch_history_for_symbol(
+            "GLOP-C", "2024-07-31", "2026-05-18"
+        )
+        assert yahoo_sym == "GLOP-PC", (
+            "fallback to Yahoo preferred form must be used when broker form "
+            "returns empty history — otherwise synthetic dividends are zero"
+        )
+        assert hist is not None and not hist.empty
+        assert calls == ["GLOP-C", "GLOP-PC"]
+
+    def test_broker_form_wins_when_it_has_data(self, monkeypatch):
+        # BRK-B is a dual-class common share that Yahoo serves directly
+        # under the broker form. The fallback exists but must not be
+        # consulted when the primary already has data.
+        import pandas as pd
+
+        from current_position_stock_price import _fetch_history_for_symbol
+
+        non_empty = pd.DataFrame(
+            {"Close": [400.0], "Dividends": [0.0]},
+            index=pd.to_datetime(["2024-08-01"]),
+        )
+
+        calls = []
+
+        def fake_ticker(sym):
+            calls.append(sym)
+            return _FakeTicker(non_empty)
+
+        monkeypatch.setattr("current_position_stock_price.yf.Ticker", fake_ticker)
+
+        hist, _, yahoo_sym = _fetch_history_for_symbol(
+            "BRK-B", "2024-07-31", "2026-05-18"
+        )
+        assert yahoo_sym == "BRK-B"
+        assert calls == ["BRK-B"], "must not query fallback when primary has rows"
+
+    def test_both_empty_returns_none(self, monkeypatch):
+        import pandas as pd
+
+        from current_position_stock_price import _fetch_history_for_symbol
+
+        empty = pd.DataFrame()
+
+        def fake_ticker(sym):
+            return _FakeTicker(empty)
+
+        monkeypatch.setattr("current_position_stock_price.yf.Ticker", fake_ticker)
+
+        hist, ticker, yahoo_sym = _fetch_history_for_symbol(
+            "ZZZZ-Q", "2024-07-31", "2026-05-18"
+        )
+        assert hist is None
+        assert ticker is None
+        assert yahoo_sym is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What the user saw

Position page `/position/GLOP-C` rendered **Dividends: $0.00** despite the user receiving **$2,809.76** in qualified dividends per the Schwab transaction history (7 quarterly events from 2024-09 through 2026-03, exactly matching the screenshots in the bug report).

## Root cause (source check first)

Followed the "source check first" rule:

1. `stg_history.action='dividend'` count for the user's GLOP-C: **0 rows**. Schwab Connect (and the manual CSV) didn't carry preferred-share dividends into the warehouse for this user, so the CSV path in `int_dividend_events.sql` produced nothing.
2. So the synthetic path should have kicked in: `stg_daily_prices.dividend × shares_held`. Counted those rows: also **0**.
3. Probed yfinance directly with the symbols we had on hand:

   | symbol | yfinance result |
   | --- | --- |
   | `GLOP-C` (Schwab broker form) | 0 rows, "possibly delisted" |
   | `GLOP-PC` (Yahoo preferred form) | 678 rows + 11 ex-div events, last close $25.77 — matches the snapshot exactly |

   Schwab normalises `GLOP/PRC` → `GLOP-C` at the API layer. Yahoo's convention for preferreds is `<root>-P<class>` (the `P` distinguishes preferred from dual-class commons like `BRK-B`). The loader was passing the broker form straight to `yf.Ticker`, getting nothing, and silently zeroing every dividend on the position.

The same bug pattern fits any Schwab-form preferred (`XYZ-A`, `XYZ-C`, …). It does not affect dual-class commons (`BRK-B`, `BF-B`) — those resolve under the broker form directly.

## Fix

`current_position_stock_price.py`:

- New `_yahoo_symbol_candidates(broker_sym)`: returns `[broker_sym]` for plain tickers, and `[broker_sym, "<root>-P<class>"]` when the broker form matches the single-letter class shape. Won't double-prefix a symbol that already has the `-P` form (e.g. SnapTrade-style `GLOP-PC` stays a single candidate).
- New `_fetch_history_for_symbol(broker_sym, start, end)`: tries each candidate in order, returns the first non-empty history. Logs which Yahoo symbol was actually used.
- Loop in the script now uses the helper and writes rows back under the **broker** symbol (the form that joins to `stg_history.underlying_symbol` everywhere downstream). No dbt or join changes required.
- Wrapped the main script body in `_main()` / `if __name__ == "__main__"` so unit tests can import the helpers without triggering `bigquery.Client()` construction at module load. Cron / `refresh.sh` invocation paths (`python current_position_stock_price.py`) keep working unchanged.

## Tests

`tests/test_yfinance_symbol_candidates.py` (13 tests, all passing):

- `TestPreferredFallback` — pins the GLOP-C → GLOP-PC mapping as the canonical regression, and confirms the fallback list contains `BRK-PB` for BRK-B even though it's never consulted at runtime (defence-in-depth shape check).
- `TestNonPreferred` — plain equities (AAPL), ETFs (JEPI), and two-letter suffixes get exactly one candidate.
- `TestEdgeCases` — empty / None / non-string input returns `[]` instead of raising.
- `TestFetchHistoryForSymbol` — end-to-end with mocked `yf.Ticker`:
  - preferred fallback wins when broker form returns empty (and only then; mocked call list pinned)
  - broker form wins for dual-class commons (fallback not consulted)
  - both-empty returns `(None, None, None)` so the caller can `continue`

Existing `tests/test_split_back_adjust_undo.py` still passes — the split-back-adjust logic is unchanged.

## End-to-end verification against Yahoo

```
Yahoo symbol fallback for 'GLOP-C': using 'GLOP-PC' (427 rows).
2024-09-09 → $0.6978  (× 500 shares = $348.92)
2024-12-09 → $0.6648  (× 500 shares = $332.40)
2025-03-10 → $0.6205  (× 500 shares = $310.23)
2025-06-09 → $0.6308  (× 500 shares = $315.41)
2025-09-08 → $0.6318  (× 500 shares = $315.89)
2025-12-08 → $0.6066  (× 1000 shares = $606.62)
2026-03-09 → $0.5803  (× 1000 shares = $580.30)
                                       --------
                              total = $2,809.76
```

These per-event totals match the user's Schwab statement to the cent.

## Surface-change consistency

- Symbol mapping happens at the loader (the single yfinance ingress point). No dbt model, route, template, or test mentions `GLOP-PC` anywhere downstream — only `GLOP-C` (the broker form we store in `daily_position_performance`, `stg_daily_prices`, `int_dividend_events`, `mart_daily_pnl`, and render to the user).
- After the next cron run / `refresh.sh`, the same code path that surfaces JEPI/SCHD/XLU dividends today will surface preferred-class dividends too — both the position page Dividends KPI and the Cumulative P&L chart's green Dividends series.
- No schema or dbt-model changes required, so no deploy-order coordination needed.

## Not in scope

- Did not change Schwab Connect's API ingestion. Schwab returns `GLOP-C` and we keep storing `GLOP-C`. The mapping only affects what we ask Yahoo for.
- Did not address dividend CSV rows that arrive with empty `Symbol` (Schwab's dividend `transferItems` sometimes omit the equity-leg symbol). That's a separate bug class — for GLOP-C the synthetic path was the only data we ever had, and it now works.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0824166d-1281-4b24-b825-6220300077df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0824166d-1281-4b24-b825-6220300077df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

