### PR TITLE
Add ETF sector fallback from yfinance

### DIFF
--- a/scripts/refresh_symbol_metadata.py
+++ b/scripts/refresh_symbol_metadata.py
@@ -4,12 +4,17 @@ name from yfinance for every ticker that shows up in stg_history (plus
 SPY/QQQ benchmarks), and load it into ccwj-dbt.analytics.symbol_metadata.
 
 We use the finance-standard hierarchy "sector → subsector". yfinance
-exposes these under the keys 'sector' and 'industry' (and a friendlier
-'industryDisp' display string), but everywhere else in this codebase
-they're called sector / subsector — including the BigQuery table this
-script writes. yfinance keys → BigQuery columns:
+exposes company tickers under the keys 'sector' and 'industry' (and a
+friendlier 'industryDisp' display string), but everywhere else in this
+codebase they're called sector / subsector — including the BigQuery table
+this script writes. yfinance keys → BigQuery columns:
   - info['sector']                       → sector
   - info['industryDisp'] or ['industry'] → subsector
+
+ETFs and mutual funds often do not populate those company fields. For
+funds, fall back to yfinance's fund-specific sector allocations:
+  - funds_data.sector_weightings max key → sector
+  - fund_overview['categoryName']        → subsector
 
 Mirrors the operational pattern of current_position_stock_price.py:
   - Read distinct symbols out of BigQuery
@@ -28,16 +33,27 @@ from __future__ import annotations
 import time
 from datetime import datetime, timezone
 
-import pandas as pd
-import yfinance as yf
-from google.cloud import bigquery
-
 TABLE_ID = "ccwj-dbt.analytics.symbol_metadata"
 BENCHMARK_TICKERS = ["SPY", "QQQ"]
 SLEEP_BETWEEN_CALLS_SEC = 0.2  # be polite to Yahoo
 
+YF_SECTOR_LABELS = {
+    "basic_materials": "Basic Materials",
+    "communication_services": "Communication Services",
+    "consumer_cyclical": "Consumer Cyclical",
+    "consumer_defensive": "Consumer Defensive",
+    "energy": "Energy",
+    "financial_services": "Financial Services",
+    "healthcare": "Healthcare",
+    "industrials": "Industrials",
+    "realestate": "Real Estate",
+    "real_estate": "Real Estate",
+    "technology": "Technology",
+    "utilities": "Utilities",
+}
 
-def _distinct_symbols(client: bigquery.Client) -> list[str]:
+
+def _distinct_symbols(client) -> list[str]:
     """All underlyings any user has ever traded, plus benchmarks. Upper/trim
     so 'aapl' / ' AAPL ' don't show up as separate rows."""
     sql = """
@@ -52,20 +68,114 @@ def _distinct_symbols(client: bigquery.Client) -> list[str]:
     return sorted(symbols)
 
 
-def _fetch_one(symbol: str) -> dict | None:
+def _clean_text(value) -> str | None:
+    if value is None:
+        return None
+
+    text = str(value).strip()
+    return text or None
+
+
+def _normalize_yf_sector_key(key) -> str | None:
+    text = _clean_text(key)
+    if not text:
+        return None
+
+    normalized = (
+        text.lower()
+        .replace("&", "and")
+        .replace("-", "_")
+        .replace(" ", "_")
+    )
+    return YF_SECTOR_LABELS.get(
+        normalized,
+        " ".join(part.capitalize() for part in normalized.split("_") if part),
+    )
+
+
+def _numeric_weight(value) -> float | None:
+    if isinstance(value, dict):
+        value = value.get("raw")
+
+    try:
+        weight = float(value)
+    except (TypeError, ValueError):
+        return None
+
+    return weight if weight > 0 else None
+
+
+def _dominant_fund_sector(sector_weightings) -> str | None:
+    if not isinstance(sector_weightings, dict):
+        return None
+
+    weighted_sectors = []
+    for key, value in sector_weightings.items():
+        label = _normalize_yf_sector_key(key)
+        weight = _numeric_weight(value)
+        if label and weight is not None:
+            weighted_sectors.append((weight, label))
+
+    if not weighted_sectors:
+        return None
+
+    return max(weighted_sectors, key=lambda item: (item[0], item[1]))[1]
+
+
+def _fund_metadata(ticker, info: dict) -> tuple[str | None, str | None]:
+    symbol = getattr(ticker, "ticker", "ticker")
+    try:
+        funds_data = ticker.funds_data
+    except Exception as exc:  # noqa: BLE001 — yfinance fund lookups are broad
+        print(f"  - {symbol}: no fund metadata from yfinance: {exc}")
+        return None, _clean_text(info.get("category"))
+
+    sector = None
+    try:
+        sector = _dominant_fund_sector(funds_data.sector_weightings)
+    except Exception as exc:  # noqa: BLE001 — one bad module should not kill refresh
+        print(f"  - {symbol}: no fund sector weightings from yfinance: {exc}")
+
+    category = _clean_text(info.get("category"))
+    try:
+        fund_overview = funds_data.fund_overview or {}
+        category = (
+            category
+            or _clean_text(fund_overview.get("categoryName"))
+            or _clean_text(fund_overview.get("legalType"))
+        )
+    except Exception as exc:  # noqa: BLE001
+        print(f"  - {symbol}: no fund category from yfinance: {exc}")
+
+    return sector, category
+
+
+def _fetch_one(symbol: str, ticker_factory=None) -> dict | None:
     """Hit yfinance for one ticker. Returns None on any error so a single
     bad ticker can't kill the whole run."""
+    if ticker_factory is None:
+        import yfinance as yf
+
+        ticker_factory = yf.Ticker
+
     try:
-        info = yf.Ticker(symbol).info or {}
+        ticker = ticker_factory(symbol)
+        info = ticker.info or {}
     except Exception as exc:  # noqa: BLE001 — yfinance raises a wide range
         print(f"  ! {symbol}: yfinance error: {exc}")
         return None
 
-    sector = info.get("sector")
+    sector = _clean_text(info.get("sector"))
     # Prefer yfinance's display string ('industryDisp') over the slug
     # ('industry'); it's the same hierarchy level but the human-readable
     # version (e.g. "Software—Application" vs "software-application").
-    subsector = info.get("industryDisp") or info.get("industry")
+    subsector = _clean_text(info.get("industryDisp")) or _clean_text(info.get("industry"))
+
+    if not sector or not subsector:
+        fund_sector, fund_subsector = _fund_metadata(ticker, info)
+        sector = sector or fund_sector
+        subsector = subsector or fund_subsector
+
     if not sector and not subsector:
         # No metadata at all — likely a delisted / OTC / synthetic symbol.
         # Still record the row so we know we tried, with Unknown placeholders.
@@ -83,6 +193,9 @@ def _fetch_one(symbol: str) -> dict | None:
 
 
 def main() -> None:
+    import pandas as pd
+    from google.cloud import bigquery
+
     client = bigquery.Client()
     symbols = _distinct_symbols(client)
     print(f"Fetching metadata for {len(symbols)} symbols...")

--- a/tests/test_refresh_symbol_metadata.py
+++ b/tests/test_refresh_symbol_metadata.py
@@ -1,0 +1,95 @@
+from scripts import refresh_symbol_metadata as metadata
+
+
+class FakeFundsData:
+    def __init__(self, sector_weightings=None, fund_overview=None):
+        self.sector_weightings = sector_weightings or {}
+        self.fund_overview = fund_overview or {}
+
+
+class FakeTicker:
+    def __init__(self, info, funds_data=None):
+        self.ticker = info.get("symbol", "FAKE")
+        self.info = info
+        self.funds_data = funds_data
+
+
+class NoFundTicker:
+    ticker = "FAKE"
+
+    def __init__(self, info):
+        self.info = info
+
+    @property
+    def funds_data(self):
+        raise RuntimeError("No Fund data found")
+
+
+def test_fetch_one_uses_yfinance_fund_sector_weightings_for_etfs():
+    ticker = FakeTicker(
+        {
+            "symbol": "SPY",
+            "quoteType": "ETF",
+            "longName": "SPDR S&P 500 ETF Trust",
+        },
+        FakeFundsData(
+            sector_weightings={
+                "technology": 0.32,
+                "healthcare": 0.11,
+                "financial_services": 0.14,
+            },
+            fund_overview={"categoryName": "Large Blend", "legalType": "ETF"},
+        ),
+    )
+
+    row = metadata._fetch_one("SPY", ticker_factory=lambda _: ticker)
+
+    assert row["sector"] == "Technology"
+    assert row["subsector"] == "Large Blend"
+    assert row["long_name"] == "SPDR S&P 500 ETF Trust"
+
+
+def test_fetch_one_preserves_company_sector_before_fund_fallback():
+    ticker = FakeTicker(
+        {
+            "symbol": "AAPL",
+            "sector": "Technology",
+            "industryDisp": "Consumer Electronics",
+            "longName": "Apple Inc.",
+        },
+        FakeFundsData(
+            sector_weightings={"healthcare": 1.0},
+            fund_overview={"categoryName": "Health"},
+        ),
+    )
+
+    row = metadata._fetch_one("AAPL", ticker_factory=lambda _: ticker)
+
+    assert row["sector"] == "Technology"
+    assert row["subsector"] == "Consumer Electronics"
+
+
+def test_fetch_one_keeps_unknown_when_yfinance_has_no_sector_metadata():
+    ticker = NoFundTicker(
+        {
+            "symbol": "DELISTED",
+            "longName": "Missing Metadata",
+        }
+    )
+
+    row = metadata._fetch_one("DELISTED", ticker_factory=lambda _: ticker)
+
+    assert row["sector"] == "Unknown"
+    assert row["subsector"] == "Unknown"
+
+
+def test_dominant_fund_sector_normalizes_yfinance_keys():
+    assert (
+        metadata._dominant_fund_sector(
+            {
+                "realestate": {"raw": 0.21},
+                "consumer_cyclical": 0.2,
+            }
+        )
+        == "Real Estate"
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add ETF/mutual-fund fallback to symbol metadata refresh using `Ticker.funds_data.sector_weightings`.
- Normalize Yahoo fund sector weighting keys into display labels and use fund category as ETF subsector.
- Add focused tests for ETF fallback, company sector preservation, and missing metadata behavior.

## Tests
- `python3 -m py_compile scripts/refresh_symbol_metadata.py tests/test_refresh_symbol_metadata.py`
- Custom local harness invoking `tests/test_refresh_symbol_metadata.py` test functions (base image does not include pytest)

## Tenancy
- No user-facing BigQuery reads changed; `symbol_metadata` remains symbol-level shared reference data.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://happy-trader.slack.com/archives/D0B1THC9BN2/p1781016841038719?thread_ts=1781016841.038719&cid=D0B1THC9BN2)

<div><a href="https://cursor.com/agents/bc-eccc9243-b781-5ab9-b11f-cbde99c69b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eccc9243-b781-5ab9-b11f-cbde99c69b88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

