### PR TITLE
Allow login with account email

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -50,6 +50,50 @@ _LANDING = {
 }
 
 
+def _lookup_login_user(identifier):
+    """Return a user for either username or email, preferring exact username."""
+    ident = (identifier or "").strip()
+    if not ident:
+        return None
+    user = User.get_by_username(ident)
+    if user is not None:
+        return user
+    if "@" not in ident:
+        return None
+    email, err = _validate_email(ident)
+    if err or not email:
+        return None
+    return User.get_by_email(email)
+
+
+def _login_attempt_keys(identifier, user=None):
+    """Keys that represent the same login target for lockout accounting."""
+    keys = []
+    for key in (
+        identifier,
+        getattr(user, "username", None),
+        getattr(user, "email", None),
+    ):
+        clean = (key or "").strip().lower()
+        if clean and clean not in keys:
+            keys.append(clean)
+    return keys
+
+
+def _login_lockout_remaining(keys):
+    return max((login_lockout_remaining_seconds(key) for key in keys), default=0)
+
+
+def _record_login_attempt_for_keys(keys, *, success, ip_address, user_agent):
+    for key in keys:
+        record_login_attempt(
+            key,
+            success=success,
+            ip_address=ip_address,
+            user_agent=user_agent,
+        )
+
+
 def _landing_endpoint(prof) -> str:
     dr = ((prof or {}).get("default_route") or "weekly_review").strip()
     if dr == "insights" and not app.config.get("INSIGHTS_ENABLED", True):
@@ -70,13 +114,15 @@ def login():
         username = request.form.get("username", "").strip()
         password = request.form.get("password", "")
         remember = request.form.get("remember") == "on"
+        user = _lookup_login_user(username)
+        attempt_keys = _login_attempt_keys(username, user)
 
-        # Per-username lockout: stop credential-stuffing that cycles IPs.
+        # Per-account lockout: stop credential-stuffing that cycles IPs.
         # The IP-keyed flask-limiter cap above blocks one host hammering
         # us; this catches a botnet probing a single account from many
-        # hosts. Cooldown is computed from the most recent failures so
-        # legitimate users naturally clear once the window slides.
-        remaining = login_lockout_remaining_seconds(username)
+        # hosts. Email login aliases share the canonical user's bucket so
+        # switching between username and email cannot bypass cooldown.
+        remaining = _login_lockout_remaining(attempt_keys)
         if remaining > 0:
             mins = max(1, (remaining + 59) // 60)
             # Don't disclose whether the username exists. Same message
@@ -89,10 +135,9 @@ def login():
             )
             return redirect(url_for("login"))
 
-        user = User.get_by_username(username)
         if user is None or not user.check_password(password):
-            record_login_attempt(
-                username,
+            _record_login_attempt_for_keys(
+                attempt_keys,
                 success=False,
                 ip_address=request.remote_addr,
                 user_agent=request.headers.get("User-Agent"),
@@ -100,7 +145,7 @@ def login():
             # Re-check after recording: this attempt may have just tipped
             # the username into lockout. Surface the imminent-lockout
             # message at the right moment.
-            after_remaining = login_lockout_remaining_seconds(username)
+            after_remaining = _login_lockout_remaining(attempt_keys)
             if after_remaining > 0:
                 mins = max(1, (after_remaining + 59) // 60)
                 flash(
@@ -110,7 +155,7 @@ def login():
                     "danger",
                 )
             else:
-                flash("Invalid username or password.", "danger")
+                flash("Invalid username/email or password.", "danger")
             nxt = safe_internal_next(
                 request.form.get("next") or request.args.get("next")
             )
@@ -118,8 +163,8 @@ def login():
                 return redirect(url_for("login", next=nxt))
             return redirect(url_for("login"))
 
-        record_login_attempt(
-            username,
+        _record_login_attempt_for_keys(
+            attempt_keys,
             success=True,
             ip_address=request.remote_addr,
             user_agent=request.headers.get("User-Agent"),

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -101,9 +101,9 @@
                 <input type="hidden" name="next" value="{{ next_for_form }}">
                 {% endif %}
                 <div class="mb-3">
-                    <label for="username" class="form-label fw-semibold small">Username</label>
+                    <label for="username" class="form-label fw-semibold small">Username or email</label>
                     <input type="text" class="form-control" id="username" name="username"
-                           placeholder="Enter your username" required autofocus>
+                           placeholder="Enter your username or email" required autofocus autocomplete="username">
                 </div>
                 <div class="mb-3">
                     <label for="password" class="form-label fw-semibold small">Password</label>

--- a/tests/test_data_isolation.py
+++ b/tests/test_data_isolation.py
@@ -44,7 +44,12 @@ def _unique_username(prefix: str = "test_iso") -> str:
     return f"{prefix}_{uuid.uuid4().hex[:8]}"
 
 
-def _create_user(conn, username: str, password: str = "testpass123") -> int:
+def _create_user(
+    conn,
+    username: str,
+    password: str = "testpass123",
+    email: str | None = None,
+) -> int:
     """Create a user via the same Postgres connection the test fixture yields.
 
     The ``db_conn`` fixture hands us a psycopg connection wrapped in
@@ -57,8 +62,8 @@ def _create_user(conn, username: str, password: str = "testpass123") -> int:
 
     with conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO users (username, password_hash) VALUES (%s, %s) RETURNING id",
-            (username, generate_password_hash(password)),
+            "INSERT INTO users (username, password_hash, email) VALUES (%s, %s, %s) RETURNING id",
+            (username, generate_password_hash(password), email),
         )
         row = cur.fetchone()
     return int(row["id"])
@@ -357,6 +362,48 @@ class TestLoginLockout:
             record_login_attempt(username.lower(), success=False, ip_address="10.0.0.1")
         # Querying with mixed case still sees the lock.
         assert login_lockout_remaining_seconds(username.upper()) > 0
+        assert login_lockout_remaining_seconds(username) > 0
+
+
+class TestLoginIdentifier:
+    """Users can recover from forgotten usernames by signing in with email."""
+
+    def test_login_accepts_email_identifier(self, client, db_conn):
+        client.post("/logout")
+        username = _unique_username("email_login")
+        email = f"{username}@example.com"
+        user_id = _create_user(db_conn, username, email=email)
+
+        response = client.post(
+            "/login",
+            data={"username": email.upper(), "password": "testpass123"},
+            follow_redirects=False,
+        )
+
+        assert response.status_code == 302
+        with client.session_transaction() as sess:
+            assert sess.get("_user_id") == str(user_id)
+        client.post("/logout")
+
+    def test_email_failures_lock_canonical_username(self, client, db_conn):
+        client.post("/logout")
+        from app.models import (
+            LOGIN_FAILURE_LIMIT,
+            login_lockout_remaining_seconds,
+        )
+
+        username = _unique_username("email_lock")
+        email = f"{username}@example.com"
+        _create_user(db_conn, username, email=email)
+
+        for _ in range(LOGIN_FAILURE_LIMIT):
+            client.post(
+                "/login",
+                data={"username": email, "password": "wrong-password"},
+                follow_redirects=False,
+            )
+
+        assert login_lockout_remaining_seconds(email) > 0
         assert login_lockout_remaining_seconds(username) > 0
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Allow the login identifier field to accept either username or account email.
- Tie email-based attempts to the same canonical account lockout keys as username attempts.
- Update login copy and add regression tests for email sign-in and lockout behavior.

## Tests
- `python3 -m compileall app/auth.py tests/test_data_isolation.py`
- `python3 -m pytest tests/test_data_isolation.py -q` *(51 skipped: `TEST_DATABASE_URL` is not configured in this environment)*
- `python3 -m pytest tests/test_safe_next.py -q` *(fails during collection: environment is missing `sentry_sdk` app dependency)*
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://happy-trader.slack.com/archives/D0B1THC9BN2/p1781017077092249?thread_ts=1781017077.092249&cid=D0B1THC9BN2)

<div><a href="https://cursor.com/agents/bc-256dc6e2-37c5-5cbd-9eb2-dbc30d5e7c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-256dc6e2-37c5-5cbd-9eb2-dbc30d5e7c40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

