### PR TITLE
Position Detail: group legs by account + turn accounts on/off

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -280,11 +280,16 @@ def _tenants_for_scope(selected_account=None):
          single physical account, even when its display label collides
          with siblings. Validated against the user's owned tenants
          (never let a URL widen tenancy); admin may address any tenant.
-      2. ``?account=<label>`` (legacy alias) — matches a base label OR a
+      2. ``?tenants=<tid>,<tid>`` — multi-account on/off toggle set (the
+         Position Detail account toggles). A SUBSET of the user's owned
+         tenants; validated the same way as ``?tenant=`` so a URL can
+         never widen tenancy. Any tenant not owned is dropped; if none of
+         the requested ids are owned we fall through to safe defaults.
+      3. ``?account=<label>`` (legacy alias) — matches a base label OR a
          disambiguated label (e.g. "Schwab Account (\u2022\u20226342)").
          A bare colliding base label still selects all matching tenants
          for backward compatibility.
-      3. No selection → admin: ``None`` (no SQL filter); user: all owned.
+      4. No selection → admin: ``None`` (no SQL filter); user: all owned.
 
     Unknown selections fall back to all of the user's tenants (same safe
     default as the v2 design doc).
@@ -309,6 +314,27 @@ def _tenants_for_scope(selected_account=None):
         if requested_tenant in owned:
             return [requested_tenant]
         # Not owned → ignore the param and fall through to safe defaults.
+
+    # 1b. Multi-tenant addressing (?tenants=) — account on/off toggles.
+    #     Encodes "show these accounts, hide the rest". Same never-widen
+    #     validation as ?tenant=; intersect with owned for non-admins.
+    try:
+        requested_tenants_raw = (request.args.get("tenants") or "").strip()
+    except Exception:
+        requested_tenants_raw = ""
+    if requested_tenants_raw:
+        requested = [t.strip() for t in requested_tenants_raw.split(",") if t.strip()]
+        if requested:
+            if admin:
+                return list(dict.fromkeys(requested))
+            owned = [
+                row["tenant_id"]
+                for row in (get_broker_tenants_for_user(current_user.id) or [])
+            ]
+            allowed = [t for t in requested if t in owned]
+            if allowed:
+                return list(dict.fromkeys(allowed))
+            # None owned → ignore the param and fall through to safe defaults.
 
     if admin and not selected:
         return None
@@ -1184,6 +1210,10 @@ def _legs_df_to_sessions_list(legs_df):
       - ``display_leg`` ← ``display_leg_num`` (chronological 1..N)
       - ``last_trade_date`` ← ``last_activity_date`` (string YYYY-MM-DD)
       - ``options_pnl`` ← ``closed_options_pnl + open_options_pnl``
+      - ``tenant_id`` / ``account`` ← carried through so legs can be
+        grouped by account when a symbol is traded across several
+        accounts (leg_id / display_leg_num restart per tenant, so the
+        template groups + labels pills by ``account_display``).
 
     Replaces ~150 lines of stateful Python (orphan-grouping, gap-id
     assignment, P&L overlap re-aggregation) — the dbt mart owns all of
@@ -1224,6 +1254,8 @@ def _legs_df_to_sessions_list(legs_df):
         out.append({
             "session_id": int(r["leg_id"]),
             "display_leg": int(r["display_leg_num"]),
+            "tenant_id": str(r.get("tenant_id") or ""),
+            "account": str(r.get("account") or ""),
             "status": str(r.get("status") or "Closed"),
             "open_date": str(od) if od is not None and not pd.isna(od) else "",
             "last_trade_date": str(ld) if ld is not None and not pd.isna(ld) else "",
@@ -2447,6 +2479,7 @@ POSITION_CLOSED_EQUITY_QUERY = """
 
 POSITION_LEGS_QUERY = """
     SELECT
+        tenant_id,
         account,
         user_id,
         symbol,
@@ -2469,7 +2502,21 @@ POSITION_LEGS_QUERY = """
     FROM `ccwj-dbt.analytics.int_position_legs`
     WHERE UPPER(TRIM(COALESCE(symbol, ''))) = UPPER(TRIM('{symbol}'))
     {tenant_filter}
-    ORDER BY account, display_leg_num
+    ORDER BY account, tenant_id, display_leg_num
+"""
+
+# Distinct accounts (tenants) that have traded this symbol, scoped to the
+# viewer's FULL owned tenant set — NOT the ?tenants= on/off subset. Powers
+# the Position Detail account-toggle bar so a toggled-OFF account can still
+# be turned back on (it must appear in the list even when it's filtered out
+# of the main legs query). Isolation is still enforced (owned tenants only).
+POSITION_ACCOUNTS_QUERY = """
+    SELECT DISTINCT
+        tenant_id,
+        account
+    FROM `ccwj-dbt.analytics.int_position_legs`
+    WHERE UPPER(TRIM(COALESCE(symbol, ''))) = UPPER(TRIM('{symbol}'))
+    {tenant_filter}
 """
 
 # Lightweight per-(account,symbol) rollup for the position-detail tab strip.
@@ -3367,8 +3414,15 @@ def position_detail(symbol):
     selected_account = request.args.get("account", "").strip()
     tenant_scope = _tenants_for_scope(selected_account)
 
+    # Full owned-tenant scope (ignores the ?tenants= on/off subset) so the
+    # account-toggle bar can list every account that traded this symbol —
+    # including ones currently toggled off. Isolation is preserved: for a
+    # non-admin this is exactly their owned tenants, for admin it's None.
+    all_owned_scope = _user_tenant_list()
+
     try:
         _pos_acct = _tenant_sql_and(tenant_scope)
+        _pos_all_acct = _tenant_sql_and(all_owned_scope)
         _pos_sc_acct = _tenant_sql_and(tenant_scope, col="sc.tenant_id")
         # POSITION_TRADES_QUERY joins stg_history (alias h) to int_drip_fills (alias d);
         # both tables have an `account` column so the filter must be scoped to h.
@@ -3405,6 +3459,12 @@ def position_detail(symbol):
             "legs": POSITION_LEGS_QUERY.format(
                 symbol=safe_symbol, tenant_filter=_pos_acct
             ),
+            # Account-toggle bar source: every account that traded this
+            # symbol across the viewer's FULL owned set (not the ?tenants=
+            # subset), so a toggled-off account is still listed.
+            "accounts_all": POSITION_ACCOUNTS_QUERY.format(
+                symbol=safe_symbol, tenant_filter=_pos_all_acct
+            ),
             # Lightweight all-symbols rollup that powers the symbol tab strip
             # at the top of the page. Scoped by `tenant_scope` so the
             # tabs match the page's account filter (when ?account= is set the
@@ -3432,6 +3492,7 @@ def position_detail(symbol):
         closed_equity_df = dfs["closed_equity"]
         matrix_df = dfs["matrix"]
         legs_df = dfs["legs"]
+        accounts_all_df = dfs.get("accounts_all", pd.DataFrame())
         tabs_df = dfs["tabs"]
         earnings_df = dfs["earnings"]
         # Fetched in the batch above; post-processed later in the route
@@ -3447,6 +3508,7 @@ def position_detail(symbol):
         closed_equity_df = _df_normalize_account_column(closed_equity_df)
         matrix_df = _df_normalize_account_column(matrix_df)
         legs_df = _df_normalize_account_column(legs_df)
+        accounts_all_df = _df_normalize_account_column(accounts_all_df)
         tabs_df = _df_normalize_account_column(tabs_df)
     except Exception as exc:
         return render_template(
@@ -3461,6 +3523,9 @@ def position_detail(symbol):
             current_positions=[],
             option_matrices=[],
             sessions=[],
+            legs_by_account=[],
+            account_toggles=[],
+            tenants_param="",
             selected_legs=[],
             leg_param="",
             chart_data_json="{}",
@@ -3580,6 +3645,66 @@ def position_detail(symbol):
     # Tenant scope already narrowed legs to the selected account's tenant.
 
     sessions_list = _legs_df_to_sessions_list(legs_df)
+
+    # ── Group legs by account ──
+    # When a symbol is traded across several accounts, leg_id / display_leg
+    # restart per tenant (so two accounts can both show "Leg 1"). Attach a
+    # disambiguated per-account label to each session so the template can
+    # GROUP the pills under account headers instead of interleaving a
+    # confusing run of duplicate leg numbers.
+    _viewer_id = getattr(current_user, "id", None)
+    _tenant_label_map = _tenant_label_map_for_user(_viewer_id)
+    _acct_nick_map = _account_label_map(_viewer_id)
+
+    def _account_display_for(tenant_id, account_raw):
+        label = _tenant_label_map.get(tenant_id or "") if tenant_id else None
+        if not label:
+            raw = account_raw or ""
+            label = _acct_nick_map.get(raw, raw)
+        return label or "Account"
+
+    for s in sessions_list:
+        s["account_display"] = _account_display_for(
+            s.get("tenant_id"), s.get("account")
+        )
+
+    legs_by_account = []
+    _leg_groups = {}
+    for s in sessions_list:
+        _leg_groups.setdefault(s.get("tenant_id") or "", []).append(s)
+    for _tid, _sess in _leg_groups.items():
+        legs_by_account.append({
+            "tenant_id": _tid,
+            "label": _sess[0].get("account_display") or "Account",
+            "sessions": _sess,
+        })
+    legs_by_account.sort(key=lambda g: g["label"])
+
+    # ── Account toggle bar (turn entire accounts on/off) ──
+    # Built from the FULL owned-tenant set (accounts_all_df), so an account
+    # that's currently toggled off still appears and can be turned back on.
+    accounts_all_df = _filter_df_by_tenant_ids(accounts_all_df, all_owned_scope)
+    selected_tenant_set = set(tenant_scope) if tenant_scope is not None else None
+    account_toggles = []
+    if (
+        accounts_all_df is not None
+        and not accounts_all_df.empty
+        and "tenant_id" in accounts_all_df.columns
+    ):
+        _seen_tids = set()
+        for _, _r in accounts_all_df.iterrows():
+            _tid = str(_r.get("tenant_id") or "")
+            if not _tid or _tid in _seen_tids:
+                continue
+            _seen_tids.add(_tid)
+            account_toggles.append({
+                "tenant_id": _tid,
+                "label": _account_display_for(_tid, str(_r.get("account") or "")),
+                "selected": True if selected_tenant_set is None else (_tid in selected_tenant_set),
+            })
+        account_toggles.sort(key=lambda a: a["label"])
+    # Preserve the current account subset on leg "Show All" / navigation.
+    tenants_param = request.args.get("tenants", "").strip()
 
     leg_param = request.args.get("leg", "")
     if leg_param:
@@ -4592,6 +4717,9 @@ def position_detail(symbol):
         current_positions=current_positions,
         option_matrices=option_matrices,
         sessions=sessions_list,
+        legs_by_account=legs_by_account,
+        account_toggles=account_toggles,
+        tenants_param=tenants_param,
         selected_legs=selected_legs,
         leg_param=leg_param,
         chart_data_json=json.dumps(_chart_data_for_json(chart_data)),

--- a/app/templates/position_detail.html
+++ b/app/templates/position_detail.html
@@ -54,6 +54,26 @@
     .session-pill .pill-dot.open  { background: #198754; }
     .session-pill .pill-dot.closed { background: #6c757d; }
     .session-pill .pill-pnl { font-size: .7rem; opacity: .8; }
+    .leg-account-group { margin-top: .5rem; }
+    .leg-account-group:first-of-type { margin-top: 0; }
+    .leg-account-label {
+        font-size: .72rem; font-weight: 700; text-transform: uppercase;
+        letter-spacing: .04em; color: #6c757d; margin-bottom: .35rem;
+    }
+    .account-toggles { display: flex; flex-wrap: wrap; gap: .5rem; align-items: center; }
+    .account-toggle {
+        display: inline-flex; align-items: center; gap: .45rem; margin: 0;
+        padding: .4rem .9rem; border-radius: 20px; font-size: .8rem; font-weight: 600;
+        cursor: pointer; user-select: none; transition: all .15s;
+        border: 2px solid #dee2e6; background: #f8f9fa; color: #adb5bd;
+    }
+    .account-toggle:hover { border-color: #6c757d; }
+    .account-toggle.active { border-color: #0d6efd; background: #e7f1ff; color: #0a58ca; }
+    .account-toggle .pill-dot {
+        width: 8px; height: 8px; border-radius: 50%; display: inline-block;
+    }
+    .account-toggle .pill-dot.open { background: #198754; }
+    .account-toggle .pill-dot.closed { background: #ced4da; }
 
     @media (max-width: 640px) {
         .pos-hero { padding: 1.25rem 1.1rem; border-radius: 12px; margin-bottom: 1rem; }
@@ -189,7 +209,11 @@
         {% endif %}
     </div>
 
-    {% if accounts|length > 1 %}
+    {# When a symbol is traded across multiple accounts the grouped
+       account-toggle bar below supersedes this single-select dropdown.
+       Keep the dropdown only for the single-account / no-toggle case
+       (e.g. picking an account that hasn't traded this symbol). #}
+    {% if accounts|length > 1 and not (account_toggles and account_toggles|length > 1) %}
     <form method="get" class="mt-3">
         <select name="account" class="form-select form-select-sm d-inline-block" style="max-width:220px; background:rgba(255,255,255,.1); color:#fff; border-color:rgba(255,255,255,.2)"
                 onchange="this.form.submit()">
@@ -327,47 +351,120 @@
     </div>
 </div>
 
-{# ── Session / Leg Filter ── #}
+{# ── Account Toggle Bar (turn entire accounts on/off) ── #}
+{% if account_toggles and account_toggles|length > 1 %}
+<div class="card stat-card p-3 mb-4">
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h6 class="fw-bold mb-0">Accounts</h6>
+        <span class="text-muted small">Traded {{ symbol }} in {{ account_toggles|length }} accounts</span>
+    </div>
+    <p class="text-muted small mb-2">Click an account to include or exclude its legs and totals.</p>
+    <div class="account-toggles" id="accountToggles">
+        {% for a in account_toggles %}
+        <label class="account-toggle {{ 'active' if a.selected }}">
+            <input type="checkbox" class="account-toggle-input" data-tenant-id="{{ a.tenant_id }}" {{ 'checked' if a.selected }} hidden>
+            <span class="pill-dot {{ 'open' if a.selected else 'closed' }}"></span>
+            <span>{{ a.label }}</span>
+        </label>
+        {% endfor %}
+    </div>
+</div>
+<script>
+(function() {
+    const inputs = document.querySelectorAll('.account-toggle-input');
+    inputs.forEach(inp => {
+        inp.addEventListener('change', () => {
+            inp.closest('.account-toggle').classList.toggle('active', inp.checked);
+            const checked = Array.from(inputs).filter(x => x.checked).map(x => x.dataset.tenantId);
+            const url = new URL(window.location);
+            // Account set changed → leg ids are per-account, so drop any leg
+            // filter and the legacy single-account params. All-on / all-off
+            // collapse to the default "everything" view.
+            url.searchParams.delete('leg');
+            url.searchParams.delete('account');
+            url.searchParams.delete('tenant');
+            if (checked.length === 0 || checked.length === inputs.length) {
+                url.searchParams.delete('tenants');
+            } else {
+                url.searchParams.set('tenants', checked.join(','));
+            }
+            window.location = url.toString();
+        });
+    });
+})();
+</script>
+{% endif %}
+
+{# ── Session / Leg Filter (grouped by account) ── #}
 {% if sessions and sessions|length > 1 %}
+{% set multi_account = legs_by_account and legs_by_account|length > 1 %}
 <div class="card stat-card p-3 mb-4">
     <div class="d-flex justify-content-between align-items-center mb-2">
         <h6 class="fw-bold mb-0">Position Legs</h6>
         {% if leg_param %}
-        <a href="{{ url_for('position_detail', symbol=symbol, account=selected_account) }}" class="btn btn-sm btn-outline-secondary">Show All</a>
+        <a href="{{ url_for('position_detail', symbol=symbol, account=(selected_account or None), tenants=(tenants_param or None)) }}" class="btn btn-sm btn-outline-secondary">Show All</a>
         {% endif %}
     </div>
-    <p class="text-muted small mb-2">Filter the entire page by leg. Click to toggle.</p>
-    <div class="session-pills" id="sessionPills">
-        {% for s in sessions %}
-        <div class="session-pill {{ 'active' if s.session_id in selected_legs }} {{ 'session-open' if s.status == 'Open' else 'session-closed' }}"
-             data-session-id="{{ s.session_id }}">
-            <span class="pill-dot {{ 'open' if s.status == 'Open' else 'closed' }}"></span>
-            <span>Leg {{ s.display_leg }}</span>
-            <span class="pill-pnl">
-                {{ s.open_date[:10] }} &rarr; {{ s.last_trade_date[:10] if s.status != 'Open' else 'now' }}
-            </span>
-            <span class="pill-pnl {% if s.combined_pnl >= 0 %}text-positive{% else %}text-negative{% endif %}">
-                ${{ "{:,.0f}".format(s.combined_pnl) }}
-            </span>
-            {% if s.options_only is defined and s.options_only %}
-            <span class="pill-pnl" style="opacity:.55; font-size:.65rem;">(options only)</span>
-            {% elif s.options_count > 0 and s.equity_pnl != 0 %}
-            <span class="pill-pnl" style="opacity:.55; font-size:.65rem;">(eq ${{ "{:,.0f}".format(s.equity_pnl) }} + {{ s.options_count }} opt)</span>
+    <p class="text-muted small mb-2">
+        {% if multi_account %}
+        Legs are grouped by account. Click a leg to focus that account and leg.
+        {% else %}
+        Filter the entire page by leg. Click to toggle.
+        {% endif %}
+    </p>
+    <div id="sessionPills" data-multi-account="{{ '1' if multi_account else '0' }}">
+        {% for grp in legs_by_account %}
+        <div class="leg-account-group">
+            {% if multi_account %}
+            <div class="leg-account-label">{{ grp.label }}</div>
             {% endif %}
+            <div class="session-pills">
+                {% for s in grp.sessions %}
+                <div class="session-pill {{ 'active' if s.session_id in selected_legs }} {{ 'session-open' if s.status == 'Open' else 'session-closed' }}"
+                     data-session-id="{{ s.session_id }}" data-tenant-id="{{ s.tenant_id }}">
+                    <span class="pill-dot {{ 'open' if s.status == 'Open' else 'closed' }}"></span>
+                    <span>Leg {{ s.display_leg }}</span>
+                    <span class="pill-pnl">
+                        {{ s.open_date[:10] }} &rarr; {{ s.last_trade_date[:10] if s.status != 'Open' else 'now' }}
+                    </span>
+                    <span class="pill-pnl {% if s.combined_pnl >= 0 %}text-positive{% else %}text-negative{% endif %}">
+                        ${{ "{:,.0f}".format(s.combined_pnl) }}
+                    </span>
+                    {% if s.options_only is defined and s.options_only %}
+                    <span class="pill-pnl" style="opacity:.55; font-size:.65rem;">(options only)</span>
+                    {% elif s.options_count > 0 and s.equity_pnl != 0 %}
+                    <span class="pill-pnl" style="opacity:.55; font-size:.65rem;">(eq ${{ "{:,.0f}".format(s.equity_pnl) }} + {{ s.options_count }} opt)</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
         </div>
         {% endfor %}
     </div>
 </div>
 <script>
 (function() {
+    const container = document.getElementById('sessionPills');
+    const multiAccount = container && container.dataset.multiAccount === '1';
     const pills = document.querySelectorAll('.session-pill');
     pills.forEach(pill => {
         pill.addEventListener('click', () => {
+            const url = new URL(window.location);
+            if (multiAccount) {
+                // Across multiple accounts a bare leg id is ambiguous (each
+                // account restarts at Leg 1). Focus this leg's account, then
+                // select just this leg — the rest of the page scopes to it.
+                url.searchParams.set('tenants', pill.dataset.tenantId);
+                url.searchParams.delete('account');
+                url.searchParams.delete('tenant');
+                url.searchParams.set('leg', pill.dataset.sessionId);
+                window.location = url.toString();
+                return;
+            }
             pill.classList.toggle('active');
             const active = document.querySelectorAll('.session-pill.active');
             const ids = Array.from(active).map(p => p.dataset.sessionId);
             const allIds = Array.from(pills).map(p => p.dataset.sessionId);
-            const url = new URL(window.location);
             if (ids.length === 0 || ids.length === allIds.length) {
                 url.searchParams.delete('leg');
             } else {

--- a/tests/test_position_detail_helpers.py
+++ b/tests/test_position_detail_helpers.py
@@ -18,12 +18,14 @@ def _legs_row(
     leg_id, display_leg_num, status, open_date, last_activity_date,
     equity_pnl=0.0, closed_options_pnl=0.0, open_options_pnl=0.0,
     options_count=0, open_options_count=0, options_only=False,
+    account="Cameron Investment", tenant_id="snaptrade:cam-uuid",
 ):
     """Shape mirrors int_position_legs SELECT — keeps the test honest about
     the mart contract."""
     combined = round(equity_pnl + closed_options_pnl + open_options_pnl, 2)
     return {
-        "account": "Cameron Investment",
+        "tenant_id": tenant_id,
+        "account": account,
         "user_id": 9,
         "symbol": "PLTR",
         "leg_id": leg_id,
@@ -439,6 +441,34 @@ def test_legs_to_sessions_list_preserves_leg_id_and_display_order():
     assert [s["display_leg"] for s in out] == [1, 2]
     assert [s["session_id"] for s in out] == [1, 2]
     assert [s["status"] for s in out] == ["Closed", "Open"]
+
+
+def test_legs_to_sessions_list_carries_tenant_and_account_for_grouping():
+    """Legs must carry ``tenant_id`` + ``account`` so the position page can
+    group pills by account when a symbol is traded across several accounts
+    (leg_id / display_leg restart per tenant → without a grouping key the
+    UI shows a confusing run of duplicate 'Leg 1' pills)."""
+    rows = [
+        _legs_row(
+            leg_id=1, display_leg_num=1, status="Closed",
+            open_date="2024-06-17", last_activity_date="2024-09-23",
+            equity_pnl=100.0,
+            account="Schwab Account", tenant_id="snaptrade:aaa",
+        ),
+        _legs_row(
+            leg_id=1, display_leg_num=1, status="Open",
+            open_date="2026-05-11", last_activity_date="2026-07-17",
+            equity_pnl=200.0,
+            account="Schwab Account", tenant_id="snaptrade:bbb",
+        ),
+    ]
+    out = _legs_df_to_sessions_list(pd.DataFrame(rows))
+    # Same display_leg / session_id across the two accounts (the collision
+    # the grouping fixes) — but distinct tenant_id keys the group.
+    assert [s["display_leg"] for s in out] == [1, 1]
+    assert [s["session_id"] for s in out] == [1, 1]
+    assert {s["tenant_id"] for s in out} == {"snaptrade:aaa", "snaptrade:bbb"}
+    assert all(s["account"] == "Schwab Account" for s in out)
 
 
 def test_legs_to_sessions_list_open_leg_merges_equity_and_live_options():

--- a/tests/test_tenant_scope_multi.py
+++ b/tests/test_tenant_scope_multi.py
@@ -1,0 +1,70 @@
+"""Unit tests for the multi-account (?tenants=) scope resolution used by
+the Position Detail account-toggle bar. See routes._tenants_for_scope."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+OWNED = [
+    {"tenant_id": "snaptrade:aaa", "account_name": "Schwab Account"},
+    {"tenant_id": "snaptrade:bbb", "account_name": "Schwab Account"},
+    {"tenant_id": "snaptrade:ccc", "account_name": "Fidelity Account"},
+]
+
+
+def _resolve(query_string, admin=False, owned=OWNED, selected_account=""):
+    from app import app
+    import app.routes as routes
+
+    user = SimpleNamespace(id=9, username="cam", is_authenticated=True)
+    with app.test_request_context("/position/AAPL" + query_string):
+        with patch.object(routes, "current_user", user), \
+             patch.object(routes, "is_admin", lambda u: admin), \
+             patch.object(
+                 routes, "get_broker_tenants_for_user", lambda uid: owned
+             ):
+            return routes._tenants_for_scope(selected_account)
+
+
+def test_tenants_param_selects_subset_of_owned():
+    scope = _resolve("?tenants=snaptrade:aaa,snaptrade:ccc")
+    assert scope == ["snaptrade:aaa", "snaptrade:ccc"]
+
+
+def test_tenants_param_drops_unowned_ids():
+    """A URL must never widen tenancy: an id the user doesn't own is dropped."""
+    scope = _resolve("?tenants=snaptrade:aaa,snaptrade:HACK")
+    assert scope == ["snaptrade:aaa"]
+
+
+def test_tenants_param_all_unowned_falls_back_to_all_owned():
+    scope = _resolve("?tenants=snaptrade:HACK1,snaptrade:HACK2")
+    assert scope == ["snaptrade:aaa", "snaptrade:bbb", "snaptrade:ccc"]
+
+
+def test_tenants_param_dedups():
+    scope = _resolve("?tenants=snaptrade:bbb,snaptrade:bbb")
+    assert scope == ["snaptrade:bbb"]
+
+
+def test_no_selection_returns_all_owned_for_user():
+    scope = _resolve("")
+    assert scope == ["snaptrade:aaa", "snaptrade:bbb", "snaptrade:ccc"]
+
+
+def test_single_tenant_param_still_wins_over_tenants():
+    """?tenant= (single, broker-stable) takes precedence over ?tenants=."""
+    scope = _resolve("?tenant=snaptrade:ccc&tenants=snaptrade:aaa,snaptrade:bbb")
+    assert scope == ["snaptrade:ccc"]
+
+
+def test_admin_tenants_param_passthrough():
+    """Admin may address any tenant set (no owned-intersection)."""
+    scope = _resolve("?tenants=snaptrade:zzz,snaptrade:yyy", admin=True)
+    assert scope == ["snaptrade:zzz", "snaptrade:yyy"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On `/position/<symbol>`, when a symbol has been traded in **multiple accounts**, the "Position Legs" strip is confusing. Legs are numbered **per account** in the mart (`int_position_legs` restarts `leg_id` / `display_leg_num` per `tenant_id`), so the flat *All Accounts* view interleaves duplicate pills — e.g. two "Leg 1" and two "Leg 2" — with no way to tell which account each belongs to (see the ASTS screenshot in the issue). There was also no way to view a subset of accounts at once — only a single-select "All Accounts / one account" dropdown.

## What this does

1. **Group legs by account.** Legs now carry `tenant_id` + a disambiguated account label. Pills render under per-account headers instead of one confusing run of colliding leg numbers. (Single-account symbols are unchanged — no headers, flat pills as before.)

2. **Turn entire accounts on/off.** A new **Accounts** toggle bar appears when a symbol was traded in more than one account. Each account is a toggle; the selected set is encoded as `?tenants=<tid,tid>` which flows through the existing tenant-scoping machinery, so KPIs, chart, breakdown, and legs are all recomputed for exactly the chosen accounts. Turning one off simply drops its `tenant_id` from scope.

3. **Unambiguous leg focus across accounts.** Because a bare leg id is ambiguous when several accounts are shown, clicking a leg pill in the multi-account view focuses that leg's account (`?tenants=<tid>&leg=<id>`) so the whole page scopes to one account and the existing date-range leg filter stays correct. Within a single account, multi-leg toggling works as before.

## Implementation

- `_tenants_for_scope`: new `?tenants=<tid,tid>` multi-account resolver with the **same never-widen validation** as `?tenant=` (unowned ids dropped; non-admins intersect with owned; admin passthrough).
- `POSITION_LEGS_QUERY`: select `tenant_id`; `_legs_df_to_sessions_list` carries `tenant_id` + `account`.
- New `POSITION_ACCOUNTS_QUERY`, scoped to the viewer's **full owned tenant set** (not the on/off subset) so a toggled-off account still appears and can be turned back on.
- Route builds `legs_by_account` (grouped, labeled) and `account_toggles` (with selected state); the legacy single-select dropdown is hidden when the toggle bar is shown.

## Tenant isolation

Every new read is scoped in **SQL** (`_tenant_sql_and`) **and** in Python (`_filter_df_by_tenant_ids`), per `bigquery-tenant-isolation.mdc`. `?tenants=` can only ever narrow to a subset of the user's owned tenants — it can never widen tenancy. Cross-**user** account sharing is untouched (isolation stays `user → owned tenant_ids`).

## Tests

- `tests/test_position_detail_helpers.py`: legs now carry `tenant_id`/`account`; new test for the two-account "same Leg 1" collision being distinguishable by tenant.
- `tests/test_tenant_scope_multi.py` (new): `?tenants=` selects a subset, drops unowned ids, falls back to all-owned when none owned, dedups, respects `?tenant=` precedence, and admin passthrough.
- Full suite: **561 passed, 67 skipped**; the only 2 failures pre-exist on `master` and are unrelated seed/data-driven tests (`test_short_option_pnl`, `test_dividends_first_class`).
- Template compiles and renders (multi-account + single-account) via `flask.render_template` smoke checks.

## Notes / follow-ups

- Deep BigQuery validation against real prod data (multiple accounts holding the same symbol) wasn't runnable in this environment (no warehouse creds); logic is covered by unit + render tests. Worth a prod spot-check on a real multi-account symbol.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b7b3e05-cfad-4666-970d-14613fc315f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b7b3e05-cfad-4666-970d-14613fc315f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

